### PR TITLE
Added Co3D dataset setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,62 @@ make install
 
 ## 🧩 Training
 
-### Prepare CO3D Dataset (Coming Soon)
+### Prepare CO3D Dataset
+
+To work with a lightweight subset of the CO3D dataset (Common Objects in 3D), follow the steps below. These instructions are adapted from the [official CO3D GitHub repository](https://github.com/facebookresearch/co3d).
+
+#### 1. Create the dataset directory
+
+Create the directory in the current project folder
 
 ```bash
-Instructions coming soon
+mkdir -p data/co3d
 ```
+
+#### 2. Clone the CO3D repository
+
+Clone the CO3D codebase **outside** of your current project folder:
+
+```bash
+git clone git@github.com:facebookresearch/co3d.git
+cd co3d/
+```
+
+#### 3. Install dependencies
+
+Install the required Python packages:
+
+```bash
+pip install visdom tqdm requests h5py
+```
+
+Then install the CO3D package itself:
+
+```bash
+pip install -e .
+```
+
+- **Note**: Make sure to install these packages in a separate environment
+
+#### 4. Download the small subset of the dataset
+
+Use the CO3D download script with the `--single_sequence_subset` flag to fetch a compact subset suitable for the many-view, single-sequence task:
+
+```bash
+python ./co3d/download_dataset.py \
+  --download_folder DOWNLOAD_FOLDER \
+  --single_sequence_subset
+```
+
+Example (downloading into this repo’s `data/co3d` folder):
+
+```bash
+python ./co3d/download_dataset.py \
+  --download_folder ../Open-Rig3R/data/co3d/ \
+  --single_sequence_subset
+```
+
+This subset requires ~8.9 GB, significantly smaller than the full dataset (~5.5 TB).
 
 ### Download the Pretrained DUSt3R Model
 


### PR DESCRIPTION
### Summary:

<!-- a super quick, one-sentence overview of what this pr does. -->
This PR adds detailed instructions for preparing the Co3D dataset for training.

### What's new:

<!-- list the key changes you've introduced. be specific but concise. -->
- added a new section "Prepare Co3D Dataset" under "training" in the `README`.
- included steps for creating the dataset directory.
- provided instructions for cloning the co3d repository and installing its dependencies.
- detailed how to download the small subset of the co3d dataset using the provided script.

### why these changes:

<!-- explain the problem this pr solves or the value it adds. what was the motivation? -->
the main motivation for this change was to simplify the setup process for users looking to train the Rig3R model with the Co3D dataset. previously, users might struggle with figuring out the correct steps for data preparation. these instructions provide a clear, step-by-step guide, ensuring smoother setup and improved reproducibility for anyone working with the Rig3R model.

### how to test:

<!-- provide clear, step-by-step instructions on how to verify your changes. this is crucial for reviewers! -->
1. review the "prepare co3d dataset" section in the `Open-Rig3R/README.md` file.
2. verify that the steps for creating the directory, cloning the co3d repo, installing dependencies, and downloading the dataset are clear, accurate, and easy to follow.
3. optionally, try following the instructions yourself to ensure they work as described and the dataset is correctly prepared.

### relevant links/screenshots (if applicable):

<!-- if you have screenshots, gifs, or links to issues/discussions, put them here. -->
- original co3d github repository: [https://github.com/facebookresearch/co3d](https://github.com/facebookresearch/co3d)

### future considerations:

<!-- anything that's out of scope for this pr but might need to be addressed later. -->
- ensure the co3d repository cloning path (`../Open-Rig3R/data/co3d/`) is robust across different user setups or provide a more flexible alternative.