### PR TITLE
feat: add Open3D visualization pipeline for Rig3R outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,27 @@ It also produces:
 
 ---
 
+## 🖼️ Visualization
+
+Inspect Rig3R predictions interactively with the Open3D visualization pipeline:
+
+```bash
+python scripts/visualize.py --config configs/evaluate.yaml
+```
+
+- **Note**: on headless machines or WSL, skip the viewer and export instead:
+
+```bash
+python scripts/visualize.py --config configs/evaluate.yaml \
+    --export outputs/scene.ply --no-show
+```
+
+Supports confidence-based filtering, four coloring modes (`rgb`, `per-camera`, `rig-cluster`, `confidence`), camera frustum overlays, and ray segment overlays.
+
+- **Note**: Check out here for [full visualization documentation](docs/VISUALIZATION.md)
+
+---
+
 ## 🧰 Citation
 
 If you use this reimplementation, please cite the original paper:

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -101,13 +101,14 @@ pip install -r requirements.txt
 
 ```bash
 # Interactive viewer — RGB colors, default settings
-python scripts/visualize.py --config configs/evaluate.yaml
+python scripts/visualize.py --config configs/evaluate.yaml --device cpu
 
 # Headless export — useful on servers or WSL
 python scripts/visualize.py \
     --config configs/evaluate.yaml \
     --export outputs/scene000.ply \
-    --no-show
+    --no-show \
+    --device cpu
 ```
 
 The config file must contain at minimum:
@@ -184,7 +185,8 @@ python scripts/visualize.py \
     --config configs/evaluate.yaml \
     --color-mode rig-cluster \
     --n-clusters 3 \
-    --seq-idx 5
+    --seq-idx 1 \
+    --device cpu
 ```
 
 Cameras belonging to the same discovered rig cluster are colored identically. Camera frustums follow the same color scheme, making it easy to see which physical cameras were grouped together.
@@ -196,7 +198,8 @@ python scripts/visualize.py \
     --config configs/evaluate.yaml \
     --color-mode confidence \
     --cmap plasma \
-    --conf-percentile 90.0
+    --conf-percentile 90.0 \
+    --device cpu
 ```
 
 Points are colored from low (dark) to high (bright) confidence. Raising `--conf-percentile` keeps fewer, higher-quality points.
@@ -208,7 +211,8 @@ python scripts/visualize.py \
     --config configs/evaluate.yaml \
     --n-frames 5 \
     --export outputs/scene001.ply \
-    --no-show
+    --no-show \
+    --device cpu
 ```
 
 The exported PLY file can be opened in MeshLab, CloudCompare, or any other tool that reads point clouds.
@@ -221,7 +225,8 @@ python scripts/visualize.py \
     --rays \
     --n-ray-samples 128 \
     --ray-length 0.3 \
-    --no-frustums
+    --no-frustums \
+    --device cpu
 ```
 
 Each green segment starts at the predicted ray origin in rig space and extends along the predicted ray direction. This is useful for verifying that the rig raymap head is outputting consistent ray geometry.

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -1,0 +1,336 @@
+# Open3D Visualization Pipeline
+
+This document explains how to use the Open3D visualization pipeline to inspect Rig3R predictions interactively. It covers installation, basic usage, all available options, and a description of how each stage of the pipeline works.
+
+---
+
+## Requirements
+
+Open3D and the other visualization dependencies are already listed in `requirements.txt`:
+
+```
+open3d >= 0.19.0
+plyfile >= 1.1.3
+matplotlib >= 3.10.7
+```
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+> **WSL / Headless note:** The interactive Open3D viewer requires a display. On WSL without an X server, skip the viewer with `--no-show` and use `--export` to save the result to a file instead.
+
+---
+
+## Quick Start
+
+```bash
+# Interactive viewer — RGB colors, default settings
+python scripts/visualize.py --config configs/evaluate.yaml
+
+# Headless export — useful on servers or WSL
+python scripts/visualize.py \
+    --config configs/evaluate.yaml \
+    --export outputs/scene000.ply \
+    --no-show
+```
+
+The config file must contain at minimum:
+
+```yaml
+checkpoint: "checkpoints/rig3r_epoch50.pt"
+data: "data/wayve_scenes_101/scene_001"
+```
+
+---
+
+## Usage
+
+```
+python scripts/visualize.py --config <path> [options]
+```
+
+### Data and model options
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--config` | required | Path to YAML config with `checkpoint` and `data` keys |
+| `--checkpoint` | from config | Override the checkpoint path |
+| `--data` | from config | Override the data root path |
+| `--seq-idx` | `0` | Index of the dataset sequence to run inference on |
+| `--n-frames` | `2` | Number of views to load per sequence |
+| `--image-size H W` | `128 128` | Inference resolution — must match the training resolution |
+
+### Confidence filtering
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--conf-percentile` | `80.0` | Keep pixels at or above this global percentile (0 = keep all) |
+
+### Point cloud coloring
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--color-mode` | `rgb` | `rgb`, `per-camera`, `rig-cluster`, or `confidence` |
+| `--cmap` | `plasma` | matplotlib colormap name, used with `--color-mode confidence` |
+| `--n-clusters` | `None` | Number of rig clusters for `rig-cluster` coloring |
+
+### Camera frustums
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--no-frustums` | — | Disable camera frustum overlay |
+| `--frustum-scale` | `0.1` | Frustum pyramid depth in world units |
+
+### Ray overlay
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--rays` | — | Enable rig_raymap ray segment overlay |
+| `--n-ray-samples` | `64` | Rays drawn per view |
+| `--ray-length` | `0.5` | Length of each ray segment in world units |
+
+### Export and display
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--export` | — | Save point cloud to this path (`.ply` or `.pcd`) |
+| `--no-show` | — | Skip the interactive viewer |
+| `--batch-idx` | `0` | Which element within the batch to visualize |
+
+---
+
+## Examples
+
+### Inspect rig structure with cluster coloring
+
+```bash
+python scripts/visualize.py \
+    --config configs/evaluate.yaml \
+    --color-mode rig-cluster \
+    --n-clusters 3 \
+    --seq-idx 5
+```
+
+Cameras belonging to the same discovered rig cluster are colored identically. Camera frustums follow the same color scheme, making it easy to see which physical cameras were grouped together.
+
+### Inspect confidence — keep only high-quality points
+
+```bash
+python scripts/visualize.py \
+    --config configs/evaluate.yaml \
+    --color-mode confidence \
+    --cmap plasma \
+    --conf-percentile 90.0
+```
+
+Points are colored from low (dark) to high (bright) confidence. Raising `--conf-percentile` keeps fewer, higher-quality points.
+
+### Export for external inspection
+
+```bash
+python scripts/visualize.py \
+    --config configs/evaluate.yaml \
+    --n-frames 5 \
+    --export outputs/scene001.ply \
+    --no-show
+```
+
+The exported PLY file can be opened in MeshLab, CloudCompare, or any other tool that reads point clouds.
+
+### Overlay predicted rays for debugging
+
+```bash
+python scripts/visualize.py \
+    --config configs/evaluate.yaml \
+    --rays \
+    --n-ray-samples 128 \
+    --ray-length 0.3 \
+    --no-frustums
+```
+
+Each green segment starts at the predicted ray origin in rig space and extends along the predicted ray direction. This is useful for verifying that the rig raymap head is outputting consistent ray geometry.
+
+---
+
+## How It Works
+
+The pipeline converts raw model outputs into Open3D geometry objects through a sequence of steps. Each step corresponds to a function in `utils/visualization.py`.
+
+### Step 1 — Inference
+
+`scripts/visualize.py` loads the model and dataset, then runs a forward pass under `torch.no_grad()`. The `cam2rig` extrinsics are withheld from the model so that it exercises the rig-discovery path (the same way it is evaluated).
+
+```
+outputs = model(images, metadata_without_cam2rig)
+```
+
+The model returns:
+
+| Key | Shape | Description |
+| :--- | :--- | :--- |
+| `pointmap` | `(B, V, H×W, 3)` | Dense 3D point predictions in camera frame |
+| `pointmap_conf` | `(B, V, H×W, 1)` | Per-pixel confidence (unbounded raw floats) |
+| `pose_raymap` | `(B, V, P, 3)` | Unit ray directions in camera frame (patch-level) |
+| `rig_raymap` | `(B, V, P, 6)` | Ray origins and directions in rig frame (patch-level) |
+
+`P = (image_size / patch_size)²`. For the default 128×128 image with patch size 8, `P = 256`.
+
+---
+
+### Step 2 — Pose resolution
+
+For each view, the pipeline decides how to obtain a camera pose `{R, t}`:
+
+1. **If `cam2rig[v]` is not identity** — the provided SE(3) matrix is used directly:
+   - `R = cam2rig[v, :3, :3]`
+   - `t = cam2rig[v, :3, 3]`
+
+2. **If `cam2rig[v]` is identity** (dropped by metadata dropout, or not provided) — the pose is recovered from the predicted rig raymap using `recover_pose_closed_form` from `utils/rig_discovery.py`. This function reshapes the `(P, 6)` raymap to `(H_patch, W_patch, 6)` and solves for `R` and `t` via SVD.
+
+This handles mixed cases: sequences where some views have real extrinsics and others do not.
+
+---
+
+### Step 3 — Confidence filtering
+
+The `PointMapHead` outputs a confidence channel with no activation function, so values are raw floats with no guaranteed range. A **global percentile threshold** is computed across all pixels in the loaded batch:
+
+```
+threshold = percentile(all_conf_values, conf_percentile)
+mask = conf >= threshold
+```
+
+`--conf-percentile 80` keeps the top 20% most confident pixels. Setting it to `0` keeps every pixel.
+
+---
+
+### Step 4 — Color computation
+
+Colors are assigned per-pixel before masking, then sampled by the mask in step 5.
+
+| Mode | How color is determined |
+| :--- | :--- |
+| `rgb` | Each pixel's color is read directly from the source image. No resampling is needed because the `pointmap` and `images` tensors share the same `H×W` resolution. |
+| `per-camera` | Each view receives a distinct solid color from the `tab20` colormap, indexed by view number. |
+| `rig-cluster` | Cameras are clustered by pose using K-means (`cluster_rig_poses`). All views in the same cluster share a `tab20` color, making rig structure immediately visible. |
+| `confidence` | Confidence values are normalized per-view (min-max within each view) and mapped through a matplotlib colormap. Per-view normalization is used so local structure is visible even when absolute confidence varies across views. |
+
+---
+
+### Step 5 — Point cloud assembly
+
+The confidence mask is applied and the surviving camera-frame points are transformed to the global rig frame:
+
+```
+p_global = R @ p_camera + t
+```
+
+This is handled by `reconstruct_pointcloud` from `utils/rig_discovery.py`. The results from all views are concatenated into a single `(N, 3)` array, matched with the corresponding `(N, 3)` colors, and passed to an `o3d.geometry.PointCloud`.
+
+Non-finite values (`NaN`, `Inf`) are removed before the Open3D objects are created. These can appear when using a randomly initialized or early-checkpoint model.
+
+---
+
+### Step 6 — Camera frustums
+
+Each camera is represented as a pyramid `LineSet` with five vertices:
+
+- **Apex** — the camera center `t` in global space.
+- **Four corners** — the image corners, projected at depth `frustum_scale` into the scene and transformed to global space via `R`.
+
+The corner directions are computed from the estimated focal length and image dimensions:
+
+```
+corner_cam = [(±W/2) / f,  (±H/2) / f,  1.0]  (normalized, then scaled)
+corner_global = R @ corner_cam + t
+```
+
+Frustum colors follow the same palette as the point cloud: `tab20` indexed by cluster label (if clustering is enabled) or by view index otherwise.
+
+---
+
+### Step 7 — Ray visualization (optional)
+
+When `--rays` is passed, `n_ray_samples` rays are uniformly sampled from each view's `rig_raymap`. Each ray is drawn as a line segment:
+
+```
+start = (ox, oy, oz)
+end   = (ox + dx * ray_length,  oy + dy * ray_length,  oz + dz * ray_length)
+```
+
+Ray origins and directions come directly from the predicted `rig_raymap` — no transformation is applied since they are already in the global rig frame.
+
+---
+
+### Step 8 — Display and export
+
+All geometry objects are passed to `o3d.visualization.draw_geometries`, which opens an interactive viewer. A coordinate frame axes indicator (`size=0.3`) is added to the scene to help with orientation but is not exported.
+
+For export, `o3d.io.write_point_cloud` is used. The format is determined by the file extension:
+
+- `.ply` — ASCII PLY (human-readable, larger file)
+- `.pcd` — binary PCD (compact, fast to load)
+
+---
+
+## Coloring Mode Reference
+
+| Mode | Best for |
+| :--- | :--- |
+| `rgb` | General scene inspection — shows the actual appearance of each point |
+| `per-camera` | Checking coverage — seeing which camera contributes which region |
+| `rig-cluster` | Rig discovery — verifying that cameras are grouped into the correct physical rigs |
+| `confidence` | Quality inspection — identifying which regions the model is uncertain about |
+
+---
+
+## Programmatic Usage
+
+The pipeline can be called directly from Python without going through the CLI:
+
+```python
+import torch
+from utils.visualization import visualize_outputs
+
+# outputs: dict from model forward pass
+# images:  (B, V, 3, H, W) float32 tensor
+result = visualize_outputs(
+    outputs=outputs,
+    images=images,
+    cam2rig=metadata.get("cam2rig"),   # optional
+    conf_percentile=80.0,
+    color_mode="rig-cluster",
+    n_clusters=3,
+    export_path="outputs/scene.ply",
+    show=False,                         # headless
+)
+
+pcd      = result["pcd"]       # o3d.geometry.PointCloud
+frustums = result["frustums"]  # list of o3d.geometry.LineSet
+poses    = result["poses"]     # list of {'R': tensor, 't': tensor}
+labels   = result["labels"]    # cluster label array or None
+```
+
+Individual primitives can also be used independently:
+
+```python
+from utils.visualization import (
+    filter_by_confidence,
+    build_camera_frustum,
+    export_point_cloud,
+)
+```
+
+---
+
+## Related Files
+
+| File | Description |
+| :--- | :--- |
+| [utils/visualization.py](../utils/visualization.py) | All visualization primitives |
+| [scripts/visualize.py](../scripts/visualize.py) | CLI entrypoint |
+| [tests/test_visualization.py](../tests/test_visualization.py) | 23 unit and integration tests |
+| [utils/rig_discovery.py](../utils/rig_discovery.py) | Pose recovery and point cloud reconstruction (called by the pipeline) |

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -4,6 +4,79 @@ This document explains how to use the Open3D visualization pipeline to inspect R
 
 ---
 
+## Installing Open3D on WSL2
+
+The interactive viewer requires a display. Follow these steps to set up X11 forwarding on WSL2 before running `scripts/visualize.py` without `--no-show`.
+
+1. Install [VcXsrv Windows X Server (XLaunch)](https://sourceforge.net/projects/vcxsrv/)
+
+2. Configure X11 via XLaunch:
+
+    **Screen 1: Multiple windows** → Next
+    ```
+    Display settings:  -multiwindow  (default)
+    Display number:  0
+    ```
+
+    **Screen 2: Uncheck Native OpenGL** ← **CRITICAL**
+    ```
+    [ ]  Native opengl   ← UNCHECK THIS (causes silent hang)
+    [✔] Start no client  ← Keep checked
+    ```
+
+    **Screen 3: Check Disable Access Control** ← **CRITICAL**
+    ```
+    [✔] Disable access control  ← CHECK THIS
+    [✔] Clipboard               ← Optional
+    [✔] Primary Selection       ← Optional
+    [✔] Extra Settings: add -wgl
+    ```
+
+    **Screen 4: Save Configuration** → Next → Finish
+
+3. Windows Firewall — when VcXsrv prompts, click **"Allow access"** and select **Private AND Public networks**.
+
+4. Add these lines to `~/.bashrc`:
+
+    ```bash
+    export XDG_SESSION_TYPE=x11
+    export DISPLAY=:0
+    export LIBGL_ALWAYS_INDIRECT=0
+    ```
+
+    Then reload your shell:
+
+    ```bash
+    source ~/.bashrc
+    ```
+
+5. Install X11 and OpenGL utilities:
+
+    ```bash
+    sudo apt-get install x11-apps mesa-utils
+    ```
+
+6. Install the Open3D viewer:
+
+    ```bash
+    wget https://github.com/isl-org/Open3D/releases/download/v0.19.0/open3d-viewer-0.19.0-Linux.deb
+    sudo mv ~/open3d-viewer-0.19.0-Linux.deb /tmp/
+    cd /tmp
+    sudo apt install -f ./open3d-viewer-0.19.0-Linux.deb
+    ```
+
+7. Verify the setup:
+
+    ```bash
+    echo $DISPLAY  # Should show: :0
+    xeyes          # Eyes should appear immediately
+    glxgears       # Gears should spin
+    wget https://raw.githubusercontent.com/McNopper/OpenGL/master/Binaries/teapot.obj
+    Open3D teapot.obj  # Teapot viewer should pop up
+    ```
+
+---
+
 ## Requirements
 
 Open3D and the other visualization dependencies are already listed in `requirements.txt`:

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -16,6 +16,7 @@ Example (headless export):
         --no-show
 """
 
+import open3d  # noqa: F401 — must be imported before torch to avoid libstdc++ conflict
 import argparse
 import sys
 import yaml
@@ -67,6 +68,12 @@ def parse_args() -> argparse.Namespace:
         "--image-size", type=int, nargs=2, default=[128, 128],
         metavar=("H", "W"),
         help="Image resolution for inference (must match training resolution).",
+    )
+    parser.add_argument(
+        "--device", type=str, default=None,
+        help="Device for inference: 'cpu' or 'cuda'. "
+             "Defaults to cuda if available. "
+             "Use --device cpu on WSL2 to avoid libdxcore/open3d conflicts.",
     )
 
     # Confidence
@@ -153,7 +160,10 @@ def main():
     args = parse_args()
     cfg = load_config(args.config)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if args.device:
+        device = torch.device(args.device)
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[visualize] Device: {device}")
 
     # Resolve paths (CLI flags override config)

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -1,0 +1,261 @@
+"""
+CLI entrypoint for the Rig3R Open3D visualization pipeline.
+
+Loads a trained Rig3R model, runs inference on a single dataset sequence,
+and visualizes the resulting point cloud with optional camera frustums and
+rig-raymap ray overlays.
+
+Usage:
+    python scripts/visualize.py --config configs/evaluate.yaml [options]
+
+Example (headless export):
+    python scripts/visualize.py \\
+        --config configs/evaluate.yaml \\
+        --color-mode rig-cluster --n-clusters 3 \\
+        --export runs/viz/scene001.ply \\
+        --no-show
+"""
+
+import argparse
+import sys
+import yaml
+import torch
+from pathlib import Path
+from torch.utils.data import DataLoader
+
+# Allow imports from project root
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from models.rig3r import Rig3R
+from datasets.wayve101 import Wayve101Dataset
+from utils.visualization import visualize_outputs
+
+
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Visualize Rig3R predictions with Open3D",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Data / model
+    parser.add_argument(
+        "--config", type=str, required=True,
+        help="Path to YAML config file (must contain 'checkpoint' and 'data' keys).",
+    )
+    parser.add_argument(
+        "--checkpoint", type=str, default=None,
+        help="Override the checkpoint path from the config file.",
+    )
+    parser.add_argument(
+        "--data", type=str, default=None,
+        help="Override the data root path from the config file.",
+    )
+    parser.add_argument(
+        "--seq-idx", type=int, default=0,
+        help="Index of the dataset sequence to run inference on.",
+    )
+    parser.add_argument(
+        "--n-frames", type=int, default=2,
+        help="Number of frames / views to load per sequence.",
+    )
+    parser.add_argument(
+        "--image-size", type=int, nargs=2, default=[128, 128],
+        metavar=("H", "W"),
+        help="Image resolution for inference (must match training resolution).",
+    )
+
+    # Confidence
+    parser.add_argument(
+        "--conf-percentile", type=float, default=80.0,
+        help="Keep pixels at or above this confidence percentile (0=keep all).",
+    )
+
+    # Coloring
+    parser.add_argument(
+        "--color-mode",
+        choices=["rgb", "per-camera", "rig-cluster", "confidence"],
+        default="rgb",
+        help="Point cloud coloring mode.",
+    )
+    parser.add_argument(
+        "--cmap", type=str, default="plasma",
+        help="matplotlib colormap name (used with --color-mode confidence).",
+    )
+    parser.add_argument(
+        "--n-clusters", type=int, default=None,
+        help="Number of rig clusters for 'rig-cluster' coloring. "
+             "None defaults to 1 (no clustering).",
+    )
+
+    # Frustums
+    parser.add_argument(
+        "--no-frustums", dest="show_frustums", action="store_false",
+        help="Disable camera frustum visualization.",
+    )
+    parser.add_argument(
+        "--frustum-scale", type=float, default=0.1,
+        help="World-space depth of camera frustum pyramids.",
+    )
+
+    # Rays
+    parser.add_argument(
+        "--rays", dest="show_rays", action="store_true",
+        help="Overlay sampled rig_raymap ray segments.",
+    )
+    parser.add_argument(
+        "--n-ray-samples", type=int, default=64,
+        help="Number of rays to draw per view (requires --rays).",
+    )
+    parser.add_argument(
+        "--ray-length", type=float, default=0.5,
+        help="World-space length of each ray segment.",
+    )
+
+    # Export / display
+    parser.add_argument(
+        "--export", type=str, default=None,
+        help="Export point cloud to this path (.ply or .pcd).",
+    )
+    parser.add_argument(
+        "--no-show", dest="show", action="store_false",
+        help="Skip the interactive Open3D viewer (useful on headless / WSL).",
+    )
+
+    # batch element (rarely needed, but available)
+    parser.add_argument(
+        "--batch-idx", type=int, default=0,
+        help="Which element within the loaded batch to visualize.",
+    )
+
+    parser.set_defaults(show_frustums=True, show_rays=False, show=True)
+    return parser.parse_args()
+
+
+# ─────────────────────────────────────────────
+# Config loading
+# ─────────────────────────────────────────────
+
+def load_config(path: str) -> dict:
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+# ─────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────
+
+def main():
+    args = parse_args()
+    cfg = load_config(args.config)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[visualize] Device: {device}")
+
+    # Resolve paths (CLI flags override config)
+    data_root = Path(args.data or cfg["data"])
+    ckpt_path = Path(args.checkpoint or cfg["checkpoint"])
+    image_size = tuple(args.image_size)  # (H, W)
+
+    # ── Dataset ──────────────────────────────
+    dataset = Wayve101Dataset(
+        root_dir=data_root,
+        n_frames=args.n_frames,
+        image_size=image_size,
+        transforms=None,
+        use_masks=False,
+    )
+    print(f"[visualize] Dataset: {len(dataset)} sequences  |  loading seq_idx={args.seq_idx}")
+
+    if args.seq_idx >= len(dataset):
+        raise IndexError(
+            f"--seq-idx {args.seq_idx} is out of range for dataset of size {len(dataset)}"
+        )
+
+    # Wrap single sample in a batch of 1
+    sample = dataset[args.seq_idx]
+    images = sample["images"].unsqueeze(0).to(device)          # (1, V, 3, H, W)
+    metadata = {
+        k: v.unsqueeze(0).to(device)
+        for k, v in sample["metadata"].items()
+        if isinstance(v, torch.Tensor)
+    }
+
+    # ── Model ────────────────────────────────
+    model = Rig3R(
+        img_size=image_size[0],
+        patch_size=8,
+        embed_dim=128,
+        metadata_dim=128,
+        num_decoder_layers=2,
+        num_heads=2,
+        mlp_dim=128 * 4,
+    )
+
+    try:
+        state_dict = torch.load(ckpt_path, map_location=device)
+        model.load_state_dict(state_dict, strict=False)
+        print(f"[visualize] Loaded checkpoint: {ckpt_path}")
+    except Exception as e:
+        print(f"[visualize] Warning: could not load checkpoint ({e})")
+        print("[visualize] Proceeding with randomly initialized model.")
+
+    model.to(device)
+    model.eval()
+
+    # ── Inference ────────────────────────────
+    # Strip cam2rig from model input so we exercise the rig-discovery path.
+    # The gt cam2rig is kept separately for pose resolution fallback.
+    model_metadata = {k: v for k, v in metadata.items() if k != "cam2rig"}
+    cam2rig = metadata.get("cam2rig")  # (1, V, 4, 4) or None
+
+    with torch.no_grad():
+        outputs = model(images, model_metadata)
+
+    print(
+        f"[visualize] Inference done  |  "
+        f"pointmap {tuple(outputs['pointmap'].shape)}  |  "
+        f"rig_raymap {tuple(outputs['rig_raymap'].shape)}"
+    )
+
+    # ── Visualize ────────────────────────────
+    result = visualize_outputs(
+        outputs=outputs,
+        images=images,
+        cam2rig=cam2rig,
+        batch_idx=args.batch_idx,
+        conf_percentile=args.conf_percentile,
+        color_mode=args.color_mode,
+        cmap_name=args.cmap,
+        show_frustums=args.show_frustums,
+        show_rays=args.show_rays,
+        n_ray_samples=args.n_ray_samples,
+        ray_length=args.ray_length,
+        frustum_scale=args.frustum_scale,
+        n_clusters=args.n_clusters,
+        export_path=args.export,
+        show=args.show,
+    )
+
+    # ── Summary ──────────────────────────────
+    labels = result["labels"]
+    if labels is not None:
+        unique, counts = zip(*sorted(
+            {int(l): int((labels == l).sum()) for l in set(labels)}.items()
+        ))
+        cluster_summary = "  ".join(
+            f"cluster {c}: {n} views" for c, n in zip(unique, counts)
+        )
+        print(f"[visualize] Rig clusters: {cluster_summary}")
+    else:
+        print(f"[visualize] No clustering (use --n-clusters N for rig-structure coloring)")
+
+    print(f"[visualize] Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,284 @@
+# tests/test_visualization.py
+import sys
+import numpy as np
+import torch
+from pathlib import Path
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from utils.visualization import (
+    filter_by_confidence,
+    compute_colors,
+    resolve_poses,
+    build_point_cloud,
+    build_camera_frustum,
+    build_all_frustums,
+    build_ray_visualization,
+    visualize_outputs,
+)
+
+# Shared dimensions: img_size=128, patch_size=8 → P=16*16=256, HW=128*128=16384
+B, V, HW, P = 1, 3, 128 * 128, 16 * 16
+H = W = 128
+
+
+def _make_outputs():
+    return {
+        "pointmap":      torch.randn(B, V, HW, 3),
+        "pointmap_conf": torch.randn(B, V, HW, 1),
+        "rig_raymap":    torch.randn(B, V, P, 6),
+        "pose_raymap":   torch.randn(B, V, P, 3),
+    }
+
+
+def _make_images():
+    return torch.rand(B, V, 3, H, W)
+
+
+# ── filter_by_confidence ──────────────────────────────────────────────────────
+
+def test_filter_by_confidence_shape():
+    conf = torch.randn(B, V, HW, 1)
+    mask = filter_by_confidence(conf, percentile=80.0)
+    assert mask.shape == (B, V, HW)
+    assert mask.dtype == torch.bool
+
+
+def test_filter_by_confidence_percentile():
+    conf = torch.randn(B, V, HW, 1)
+    mask = filter_by_confidence(conf, percentile=80.0)
+    # ~20 % of pixels kept at the 80th percentile
+    kept_frac = mask.float().mean().item()
+    assert 0.15 < kept_frac < 0.25, f"unexpected keep fraction: {kept_frac:.3f}"
+
+
+def test_filter_by_confidence_zero_percentile():
+    conf = torch.randn(B, V, HW, 1)
+    mask = filter_by_confidence(conf, percentile=0.0)
+    assert mask.all(), "percentile=0 should keep every pixel"
+
+
+def test_filter_by_confidence_squeezed_input():
+    # Should also accept (B, V, HW) without trailing dim
+    conf = torch.randn(B, V, HW)
+    mask = filter_by_confidence(conf, percentile=50.0)
+    assert mask.shape == (B, V, HW)
+
+
+# ── compute_colors ────────────────────────────────────────────────────────────
+
+def test_compute_colors_rgb():
+    images = _make_images()
+    conf = torch.randn(B, V, HW)
+    colors = compute_colors(images, conf, None, mode="rgb")
+    assert colors.shape == (B, V, HW, 3)
+    assert colors.min() >= 0.0 and colors.max() <= 1.0
+
+
+def test_compute_colors_per_camera():
+    images = _make_images()
+    conf = torch.randn(B, V, HW)
+    colors = compute_colors(images, conf, None, mode="per-camera")
+    assert colors.shape == (B, V, HW, 3)
+    # All pixels in a given view share the same color
+    for v in range(V):
+        assert torch.allclose(colors[0, v, 0], colors[0, v, 1])
+
+
+def test_compute_colors_confidence():
+    images = _make_images()
+    conf = torch.randn(B, V, HW)
+    colors = compute_colors(images, conf, None, mode="confidence", cmap_name="plasma")
+    assert colors.shape == (B, V, HW, 3)
+
+
+def test_compute_colors_rig_cluster():
+    images = _make_images()
+    conf = torch.randn(B, V, HW)
+    labels = np.array([0, 0, 1])
+    colors = compute_colors(images, conf, labels, mode="rig-cluster")
+    assert colors.shape == (B, V, HW, 3)
+    # Views in the same cluster must share the same solid color
+    assert torch.allclose(colors[0, 0, 0], colors[0, 1, 0])
+    assert not torch.allclose(colors[0, 0, 0], colors[0, 2, 0])
+
+
+# ── resolve_poses ─────────────────────────────────────────────────────────────
+
+def test_resolve_poses_no_cam2rig():
+    rig_raymap = torch.randn(V, P, 6)
+    poses = resolve_poses(rig_raymap, cam2rig=None)
+    assert len(poses) == V
+    for p in poses:
+        assert "R" in p and "t" in p
+        assert p["R"].shape == (3, 3)
+        assert p["t"].shape == (3,)
+
+
+def test_resolve_poses_all_identity_falls_back():
+    rig_raymap = torch.randn(V, P, 6)
+    cam2rig = torch.eye(4).unsqueeze(0).repeat(V, 1, 1)  # all identity
+    poses = resolve_poses(rig_raymap, cam2rig=cam2rig)
+    assert len(poses) == V
+
+
+def test_resolve_poses_uses_provided_cam2rig():
+    rig_raymap = torch.randn(V, P, 6)
+    cam2rig = torch.eye(4).unsqueeze(0).repeat(V, 1, 1)
+    expected_t = torch.tensor([1.0, 2.0, 3.0])
+    cam2rig[0, :3, 3] = expected_t  # make view 0 non-identity
+    poses = resolve_poses(rig_raymap, cam2rig=cam2rig)
+    assert torch.allclose(poses[0]["t"], expected_t)
+
+
+# ── build_point_cloud ─────────────────────────────────────────────────────────
+
+def test_build_point_cloud_output_type():
+    import open3d as o3d
+    rig_raymap = torch.randn(V, P, 6)
+    poses = resolve_poses(rig_raymap, cam2rig=None)
+    conf = torch.randn(B, V, HW, 1)
+    conf_mask = filter_by_confidence(conf, 80.0)[0]   # (V, HW)
+    images = _make_images()
+    colors_v = compute_colors(images, conf.squeeze(-1), None, "rgb")[0]  # (V,HW,3)
+    pointmaps = torch.randn(V, HW, 3)
+    pcd = build_point_cloud(pointmaps, conf_mask, colors_v, poses)
+    assert isinstance(pcd, o3d.geometry.PointCloud)
+    assert len(pcd.points) > 0
+    assert len(pcd.colors) == len(pcd.points)
+
+
+def test_build_point_cloud_no_nan():
+    import open3d as o3d
+    import numpy as np
+    rig_raymap = torch.randn(V, P, 6)
+    poses = resolve_poses(rig_raymap, cam2rig=None)
+    conf = torch.randn(B, V, HW, 1)
+    conf_mask = filter_by_confidence(conf, 0.0)[0]    # keep all
+    images = _make_images()
+    colors_v = compute_colors(images, conf.squeeze(-1), None, "rgb")[0]
+    pointmaps = torch.randn(V, HW, 3)
+    # Inject some NaN/Inf values
+    pointmaps[0, 0] = float("nan")
+    pointmaps[1, 0] = float("inf")
+    pcd = build_point_cloud(pointmaps, conf_mask, colors_v, poses)
+    pts = np.asarray(pcd.points)
+    assert np.isfinite(pts).all(), "point cloud must not contain NaN or Inf"
+
+
+# ── build_camera_frustum ──────────────────────────────────────────────────────
+
+def test_build_camera_frustum_edges():
+    import open3d as o3d
+    frustum = build_camera_frustum(
+        np.eye(3), np.zeros(3), focal_length=128.0,
+        img_hw=(H, W), scale=0.1,
+    )
+    assert isinstance(frustum, o3d.geometry.LineSet)
+    assert len(frustum.lines) == 8
+    assert len(frustum.points) == 5
+
+
+def test_build_all_frustums_count():
+    rig_raymap = torch.randn(V, P, 6)
+    poses = resolve_poses(rig_raymap, cam2rig=None)
+    frustums = build_all_frustums(poses, cluster_labels=None, focal_lengths=None, img_hw=(H, W))
+    assert len(frustums) == V
+
+
+def test_build_all_frustums_cluster_coloring():
+    import open3d as o3d
+    rig_raymap = torch.randn(V, P, 6)
+    poses = resolve_poses(rig_raymap, cam2rig=None)
+    labels = np.array([0, 0, 1])
+    frustums = build_all_frustums(poses, cluster_labels=labels, focal_lengths=None, img_hw=(H, W))
+    assert len(frustums) == V
+    # Views 0 and 1 are in the same cluster → same edge colors
+    c0 = np.asarray(frustums[0].colors)[0]
+    c1 = np.asarray(frustums[1].colors)[0]
+    c2 = np.asarray(frustums[2].colors)[0]
+    assert np.allclose(c0, c1)
+    assert not np.allclose(c0, c2)
+
+
+# ── build_ray_visualization ───────────────────────────────────────────────────
+
+def test_build_ray_visualization_segment_count():
+    rig_raymap = torch.randn(V, P, 6)
+    n_samples = 8
+    rays = build_ray_visualization(rig_raymap, n_samples=n_samples, ray_length=0.5)
+    assert len(rays.lines) == V * n_samples
+    assert len(rays.points) == V * n_samples * 2
+
+
+def test_build_ray_visualization_finite_points():
+    import numpy as np
+    rig_raymap = torch.randn(V, P, 6)
+    rays = build_ray_visualization(rig_raymap, n_samples=16)
+    pts = np.asarray(rays.points)
+    assert np.isfinite(pts).all()
+
+
+# ── visualize_outputs (end-to-end, headless) ──────────────────────────────────
+
+def test_visualize_outputs_returns_pcd():
+    import open3d as o3d
+    result = visualize_outputs(
+        _make_outputs(), _make_images(),
+        cam2rig=None,
+        conf_percentile=80.0,
+        color_mode="per-camera",
+        show_frustums=True,
+        show_rays=True,
+        n_ray_samples=8,
+        show=False,
+    )
+    assert isinstance(result["pcd"], o3d.geometry.PointCloud)
+    assert len(result["pcd"].points) > 0
+    assert len(result["frustums"]) == V
+    assert result["rays"] is not None
+
+
+def test_visualize_outputs_all_color_modes():
+    for mode in ["rgb", "per-camera", "confidence"]:
+        result = visualize_outputs(
+            _make_outputs(), _make_images(),
+            color_mode=mode, show=False,
+        )
+        assert len(result["pcd"].points) > 0, f"no points for color_mode={mode}"
+
+
+def test_visualize_outputs_rig_cluster_mode():
+    result = visualize_outputs(
+        _make_outputs(), _make_images(),
+        color_mode="rig-cluster",
+        n_clusters=2,
+        show=False,
+    )
+    assert result["labels"] is not None
+    assert len(result["labels"]) == V
+
+
+def test_visualize_outputs_export(tmp_path):
+    out_ply = str(tmp_path / "test_output.ply")
+    visualize_outputs(
+        _make_outputs(), _make_images(),
+        export_path=out_ply, show=False,
+    )
+    assert Path(out_ply).exists()
+    assert Path(out_ply).stat().st_size > 0
+
+
+def test_visualize_outputs_no_frustums_no_rays():
+    result = visualize_outputs(
+        _make_outputs(), _make_images(),
+        show_frustums=False, show_rays=False, show=False,
+    )
+    assert result["frustums"] == []
+    assert result["rays"] is None
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -1,0 +1,574 @@
+"""
+Open3D visualization pipeline for Rig3R outputs.
+
+Provides primitives for converting raw model outputs (pointmaps, confidence,
+raymaps, poses) into Open3D geometries, plus a top-level convenience function
+that runs the full pipeline.
+"""
+
+import numpy as np
+import torch
+import open3d as o3d
+import matplotlib.cm as mpl_cm
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from utils.rig_discovery import (
+    recover_pose_closed_form,
+    cluster_rig_poses,
+    reconstruct_pointcloud,
+)
+
+# ─────────────────────────────────────────────
+# 1. Confidence filtering
+# ─────────────────────────────────────────────
+
+def filter_by_confidence(
+    conf: torch.Tensor,
+    percentile: float = 80.0,
+) -> torch.Tensor:
+    """
+    Build a boolean keep-mask from raw confidence values.
+
+    The confidence channel from PointMapHead has no activation function, so
+    values are arbitrary floats — higher means more confident.  A global
+    percentile threshold is used so that views with uniformly low confidence
+    do not contribute disproportionate points.
+
+    Args:
+        conf:       (B, V, H*W, 1) or (B, V, H*W) float tensor.
+        percentile: Keep pixels at or above this percentile, computed globally
+                    across all pixels in the batch.  0.0 keeps everything.
+
+    Returns:
+        mask: (B, V, H*W) bool tensor. True = include this pixel.
+    """
+    # Squeeze trailing dim if present
+    if conf.dim() == 4 and conf.shape[-1] == 1:
+        conf = conf.squeeze(-1)  # (B, V, H*W)
+
+    if percentile <= 0.0:
+        return torch.ones_like(conf, dtype=torch.bool)
+
+    threshold = torch.quantile(conf.float().reshape(-1), percentile / 100.0)
+    return conf >= threshold
+
+
+# ─────────────────────────────────────────────
+# 2. Color computation
+# ─────────────────────────────────────────────
+
+def _tab20_color(idx: int) -> Tuple[float, float, float]:
+    """Return an RGB tuple from the tab20 colormap."""
+    return mpl_cm.get_cmap("tab20")(idx % 20)[:3]
+
+
+def compute_colors(
+    images: torch.Tensor,
+    conf: torch.Tensor,
+    cluster_labels: Optional[np.ndarray],
+    mode: str = "rgb",
+    cmap_name: str = "plasma",
+) -> torch.Tensor:
+    """
+    Compute per-pixel RGB colors for all views.
+
+    Args:
+        images:         (B, V, 3, H, W) float32 [0, 1] source images.
+        conf:           (B, V, H*W) float tensor (squeezed, before masking).
+        cluster_labels: (V,) int array from cluster_rig_poses, or None.
+                        Only used for 'rig-cluster' mode.
+        mode:           'rgb'        — per-pixel color from source image
+                        'per-camera' — each view gets a solid tab20 color
+                        'rig-cluster'— views in same cluster share a tab20 color
+                        'confidence' — matplotlib cmap applied to per-view
+                                       min-max normalized confidence
+        cmap_name:      matplotlib colormap name used for 'confidence' mode.
+
+    Returns:
+        colors: (B, V, H*W, 3) float32 [0, 1] RGB tensor.
+    """
+    B, V, _, H, W = images.shape
+    HW = H * W
+    device = images.device
+
+    if mode == "rgb":
+        # (B, V, 3, H, W) → (B, V, H, W, 3) → (B, V, H*W, 3)
+        colors = images.permute(0, 1, 3, 4, 2).reshape(B, V, HW, 3)
+        colors = colors.clamp(0.0, 1.0)
+
+    elif mode == "per-camera":
+        colors = torch.zeros(B, V, HW, 3, device=device)
+        for v in range(V):
+            c = torch.tensor(_tab20_color(v), dtype=torch.float32, device=device)
+            colors[:, v, :, :] = c.unsqueeze(0).expand(HW, 3)
+
+    elif mode == "rig-cluster":
+        if cluster_labels is None:
+            # Fall back to per-camera coloring if no cluster info
+            cluster_labels = np.arange(V)
+        colors = torch.zeros(B, V, HW, 3, device=device)
+        for v in range(V):
+            c = torch.tensor(
+                _tab20_color(int(cluster_labels[v])),
+                dtype=torch.float32,
+                device=device,
+            )
+            colors[:, v, :, :] = c.unsqueeze(0).expand(HW, 3)
+
+    elif mode == "confidence":
+        cmap = mpl_cm.get_cmap(cmap_name)
+        colors = torch.zeros(B, V, HW, 3, device=device)
+        for b in range(B):
+            for v in range(V):
+                c_flat = conf[b, v].float().cpu().numpy()  # (H*W,)
+                c_min, c_max = c_flat.min(), c_flat.max()
+                if c_max > c_min:
+                    c_norm = (c_flat - c_min) / (c_max - c_min)
+                else:
+                    c_norm = np.zeros_like(c_flat)
+                c_rgb = torch.tensor(
+                    cmap(c_norm)[:, :3], dtype=torch.float32, device=device
+                )
+                colors[b, v] = c_rgb
+    else:
+        raise ValueError(
+            f"Unknown color mode '{mode}'. "
+            "Choose from: rgb, per-camera, rig-cluster, confidence"
+        )
+
+    return colors
+
+
+# ─────────────────────────────────────────────
+# 3. Pose resolution
+# ─────────────────────────────────────────────
+
+def resolve_poses(
+    rig_raymap: torch.Tensor,
+    cam2rig: Optional[torch.Tensor],
+) -> List[Dict[str, torch.Tensor]]:
+    """
+    Produce per-view poses for a single batch element.
+
+    For each view:
+    - If cam2rig[v] is not an identity matrix, extract R and t from it.
+    - Otherwise fall back to recover_pose_closed_form(rig_raymap[v]).
+
+    This handles partial metadata dropout gracefully: views that have real
+    extrinsics use them; views with identity matrices (dropped during training)
+    are recovered from the predicted rig raymap.
+
+    Args:
+        rig_raymap: (V, P, 6) tensor for one batch element.
+        cam2rig:    (V, 4, 4) SE(3) tensor for one batch element, or None.
+
+    Returns:
+        List of V dicts, each {'R': (3,3) tensor, 't': (3,) tensor}.
+    """
+    V, P, _ = rig_raymap.shape
+    H_p = int(P ** 0.5)
+    poses = []
+
+    for v in range(V):
+        use_provided = False
+        if cam2rig is not None:
+            eye4 = torch.eye(4, device=cam2rig.device, dtype=cam2rig.dtype)
+            if not torch.allclose(cam2rig[v], eye4, atol=1e-4):
+                use_provided = True
+
+        if use_provided:
+            R_mat = cam2rig[v, :3, :3]
+            t_vec = cam2rig[v, :3, 3]
+            poses.append({"R": R_mat, "t": t_vec})
+        else:
+            rmap = rig_raymap[v].reshape(H_p, H_p, 6)
+            pose = recover_pose_closed_form(rmap)
+            poses.append(pose)
+
+    return poses
+
+
+# ─────────────────────────────────────────────
+# 4. Point cloud assembly
+# ─────────────────────────────────────────────
+
+def build_point_cloud(
+    pointmaps: torch.Tensor,
+    conf_mask: torch.Tensor,
+    colors: torch.Tensor,
+    poses: List[Dict[str, torch.Tensor]],
+) -> o3d.geometry.PointCloud:
+    """
+    Assemble an Open3D PointCloud for a single batch element.
+
+    Args:
+        pointmaps:  (V, H*W, 3) float tensor, camera-frame 3D points.
+        conf_mask:  (V, H*W) bool tensor; True pixels are included.
+        colors:     (V, H*W, 3) float32 [0, 1] tensor.
+        poses:      list of V dicts {'R': (3,3), 't': (3,)}.
+
+    Returns:
+        o3d.geometry.PointCloud with .points and .colors set.
+    """
+    V = pointmaps.shape[0]
+
+    pmaps_list = [pointmaps[v] for v in range(V)]          # list of (H*W, 3)
+    masks_list = [conf_mask[v] for v in range(V)]          # list of (H*W,)
+
+    # reconstruct_pointcloud reshapes each pmap to (-1, 3) internally
+    global_pts = reconstruct_pointcloud(pmaps_list, poses, masks_list)  # (N, 3)
+
+    # Gather colors in the same view-major order
+    color_list = [colors[v][conf_mask[v]] for v in range(V)]  # list of (n_v, 3)
+    all_colors = torch.cat(color_list, dim=0)                  # (N, 3)
+
+    pts_np = global_pts.cpu().detach().float().numpy()
+    col_np = all_colors.cpu().detach().float().numpy()
+
+    # Remove non-finite points (can occur with random-init models)
+    valid = np.isfinite(pts_np).all(axis=1)
+    pts_np = pts_np[valid]
+    col_np = col_np[valid]
+
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(pts_np.astype(np.float64))
+    pcd.colors = o3d.utility.Vector3dVector(np.clip(col_np, 0.0, 1.0).astype(np.float64))
+    return pcd
+
+
+# ─────────────────────────────────────────────
+# 5. Camera frustum visualization
+# ─────────────────────────────────────────────
+
+def build_camera_frustum(
+    R: np.ndarray,
+    t: np.ndarray,
+    focal_length: float,
+    img_hw: Tuple[int, int],
+    scale: float = 0.1,
+    color: Tuple[float, float, float] = (1.0, 0.0, 0.0),
+) -> o3d.geometry.LineSet:
+    """
+    Build a LineSet camera-frustum pyramid (apex + 4 projected image corners).
+
+    Args:
+        R:            (3, 3) numpy array, cam→global rotation.
+        t:            (3,) numpy array, camera center in global frame.
+        focal_length: Estimated focal length in pixels.
+        img_hw:       (H, W) image resolution.
+        scale:        World-space depth of the frustum (controls visual size).
+        color:        (r, g, b) float [0, 1] for all edges.
+
+    Returns:
+        o3d.geometry.LineSet with 8 edges.
+    """
+    H, W = img_hw
+    cx, cy = W / 2.0, H / 2.0
+    f = float(focal_length) if focal_length > 0 else float(W)
+
+    # 4 image corners in camera frame, projected at depth=scale
+    corners_cam = np.array([
+        [(0 - cx) / f,  (0 - cy) / f,  1.0],
+        [(W - cx) / f,  (0 - cy) / f,  1.0],
+        [(W - cx) / f,  (H - cy) / f,  1.0],
+        [(0 - cx) / f,  (H - cy) / f,  1.0],
+    ])
+    # Normalize and scale to desired world depth
+    norms = np.linalg.norm(corners_cam, axis=1, keepdims=True)
+    corners_cam = corners_cam / norms * scale
+
+    # Transform to global frame: p_global = R @ p_cam + t
+    corners_global = (R @ corners_cam.T).T + t  # (4, 3)
+
+    # 5 points: apex (camera center) + 4 corners
+    apex = t.reshape(1, 3)
+    points = np.vstack([apex, corners_global])  # (5, 3)
+
+    # 8 edges: 4 from apex to each corner + 4 forming the base rectangle
+    lines = [
+        [0, 1], [0, 2], [0, 3], [0, 4],  # apex → corners
+        [1, 2], [2, 3], [3, 4], [4, 1],  # base rectangle
+    ]
+    colors_list = [list(color)] * 8
+
+    lineset = o3d.geometry.LineSet()
+    lineset.points = o3d.utility.Vector3dVector(points.astype(np.float64))
+    lineset.lines = o3d.utility.Vector2iVector(lines)
+    lineset.colors = o3d.utility.Vector3dVector(colors_list)
+    return lineset
+
+
+def build_all_frustums(
+    poses: List[Dict[str, torch.Tensor]],
+    cluster_labels: Optional[np.ndarray],
+    focal_lengths: Optional[List[float]],
+    img_hw: Tuple[int, int],
+    frustum_scale: float = 0.1,
+) -> List[o3d.geometry.LineSet]:
+    """
+    Build one frustum LineSet per camera view.
+
+    Color is determined by cluster_labels (if provided) or by view index,
+    using the tab20 colormap.
+
+    Args:
+        poses:          list of V dicts {'R', 't'} (tensors, any device).
+        cluster_labels: (V,) int array or None.
+        focal_lengths:  list of V focal lengths, or None (uses img_hw[1]).
+        img_hw:         (H, W) image resolution.
+        frustum_scale:  see build_camera_frustum.
+
+    Returns:
+        list of V o3d.geometry.LineSet.
+    """
+    frustums = []
+    V = len(poses)
+    for v, pose in enumerate(poses):
+        label = int(cluster_labels[v]) if cluster_labels is not None else v
+        color = _tab20_color(label)
+        fl = focal_lengths[v] if focal_lengths is not None else float(img_hw[1])
+        R_np = pose["R"].cpu().detach().float().numpy()
+        t_np = pose["t"].cpu().detach().float().numpy()
+        frustums.append(
+            build_camera_frustum(R_np, t_np, fl, img_hw, frustum_scale, color)
+        )
+    return frustums
+
+
+# ─────────────────────────────────────────────
+# 6. Ray visualization
+# ─────────────────────────────────────────────
+
+def build_ray_visualization(
+    rig_raymap: torch.Tensor,
+    n_samples: int = 64,
+    ray_length: float = 0.5,
+    color: Tuple[float, float, float] = (0.0, 1.0, 0.5),
+) -> o3d.geometry.LineSet:
+    """
+    Draw uniformly sampled rig_raymap rays as line segments.
+
+    Args:
+        rig_raymap: (V, P, 6) tensor for one batch element.
+                    Each entry is (ox, oy, oz, dx, dy, dz) in rig frame.
+        n_samples:  Rays to draw per view (uniformly sampled from P patches).
+        ray_length: Length of each segment in world units.
+        color:      (r, g, b) for all segments.
+
+    Returns:
+        o3d.geometry.LineSet where each segment is one ray.
+    """
+    V, P, _ = rig_raymap.shape
+    indices = torch.linspace(0, P - 1, min(n_samples, P)).long()
+
+    all_starts = []
+    all_ends = []
+
+    for v in range(V):
+        sampled = rig_raymap[v][indices]  # (n_samples, 6)
+        origins = sampled[:, :3].cpu().detach().float().numpy()
+        dirs = sampled[:, 3:].cpu().detach().float().numpy()
+        # Normalize directions for consistent segment length
+        norms = np.linalg.norm(dirs, axis=1, keepdims=True) + 1e-8
+        dirs = dirs / norms
+        all_starts.append(origins)
+        all_ends.append(origins + dirs * ray_length)
+
+    starts = np.vstack(all_starts)  # (V*n_samples, 3)
+    ends = np.vstack(all_ends)       # (V*n_samples, 3)
+
+    n_rays = len(starts)
+    points = np.vstack([starts, ends])  # (2*n_rays, 3)
+    lines = [[i, i + n_rays] for i in range(n_rays)]
+    colors_list = [list(color)] * n_rays
+
+    lineset = o3d.geometry.LineSet()
+    lineset.points = o3d.utility.Vector3dVector(points.astype(np.float64))
+    lineset.lines = o3d.utility.Vector2iVector(lines)
+    lineset.colors = o3d.utility.Vector3dVector(colors_list)
+    return lineset
+
+
+# ─────────────────────────────────────────────
+# 7. Export
+# ─────────────────────────────────────────────
+
+def export_point_cloud(pcd: o3d.geometry.PointCloud, path: str) -> None:
+    """
+    Write a point cloud to disk in PLY or PCD format.
+
+    The format is determined by the file extension (.ply or .pcd).
+    Parent directories are created automatically.
+
+    Args:
+        pcd:  Open3D PointCloud.
+        path: Output file path.
+    """
+    out = Path(path)
+    ext = out.suffix.lower()
+    if ext not in {".ply", ".pcd"}:
+        raise ValueError(f"Unsupported extension '{ext}'. Use .ply or .pcd.")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    write_ascii = ext == ".ply"
+    ok = o3d.io.write_point_cloud(str(out), pcd, write_ascii=write_ascii)
+    if not ok:
+        raise RuntimeError(f"open3d failed to write point cloud to {out}")
+    print(f"Exported point cloud ({len(pcd.points)} points) → {out}")
+
+
+# ─────────────────────────────────────────────
+# 8. Top-level pipeline
+# ─────────────────────────────────────────────
+
+def visualize_outputs(
+    outputs: Dict[str, torch.Tensor],
+    images: torch.Tensor,
+    cam2rig: Optional[torch.Tensor] = None,
+    batch_idx: int = 0,
+    conf_percentile: float = 80.0,
+    color_mode: str = "rgb",
+    cmap_name: str = "plasma",
+    show_frustums: bool = True,
+    show_rays: bool = False,
+    n_ray_samples: int = 64,
+    ray_length: float = 0.5,
+    frustum_scale: float = 0.1,
+    n_clusters: Optional[int] = None,
+    export_path: Optional[str] = None,
+    show: bool = True,
+) -> Dict[str, object]:
+    """
+    Full pipeline: raw Rig3R outputs → Open3D geometries.
+
+    Optionally exports the point cloud and/or opens an interactive viewer.
+
+    Args:
+        outputs:         dict with keys 'pointmap' (B,V,H*W,3),
+                         'pointmap_conf' (B,V,H*W,1), 'rig_raymap' (B,V,P,6).
+        images:          (B, V, 3, H, W) float32 [0, 1] source images.
+        cam2rig:         (B, V, 4, 4) SE(3) matrices or None.
+        batch_idx:       Which element in the batch to visualize.
+        conf_percentile: Confidence threshold percentile (0–100).
+        color_mode:      'rgb' | 'per-camera' | 'rig-cluster' | 'confidence'.
+        cmap_name:       matplotlib cmap name for 'confidence' mode.
+        show_frustums:   Whether to include camera frustum LineSet objects.
+        show_rays:       Whether to include rig_raymap ray segments.
+        n_ray_samples:   Rays per view when show_rays is True.
+        ray_length:      Ray segment length in world units.
+        frustum_scale:   Frustum pyramid depth in world units.
+        n_clusters:      Number of rig clusters for 'rig-cluster' coloring.
+                         None defaults to 1 (all same cluster).
+        export_path:     If set, write point cloud to this path (.ply/.pcd).
+        show:            If True, open interactive Open3D viewer (blocking).
+
+    Returns:
+        dict with keys:
+            'pcd':      o3d.geometry.PointCloud
+            'frustums': list of o3d.geometry.LineSet
+            'rays':     o3d.geometry.LineSet or None
+            'poses':    list of pose dicts
+            'labels':   cluster label array or None
+    """
+    b = batch_idx
+    pointmaps = outputs["pointmap"][b]          # (V, H*W, 3)
+    conf = outputs["pointmap_conf"][b]          # (V, H*W, 1)
+    rig_raymap = outputs["rig_raymap"][b]       # (V, P, 6)
+    imgs_b = images[b]                          # (V, 3, H, W)
+    cam2rig_b = cam2rig[b] if cam2rig is not None else None
+
+    V = pointmaps.shape[0]
+    _, H, W = imgs_b.shape[0], imgs_b.shape[2], imgs_b.shape[3]
+
+    # Step 1: Resolve poses
+    poses = resolve_poses(rig_raymap, cam2rig_b)
+
+    # Step 2: Cluster (needed for 'rig-cluster' coloring and frustum colors)
+    cluster_labels = None
+    if n_clusters is not None and n_clusters > 1:
+        cluster_labels = cluster_rig_poses(poses, n_clusters=n_clusters)
+    elif color_mode == "rig-cluster" and n_clusters is None:
+        print(
+            "[visualize] Warning: --color-mode rig-cluster with n_clusters=None "
+            "defaults to 1 cluster (all same color). Pass --n-clusters N for "
+            "meaningful rig-structure coloring."
+        )
+
+    # Step 3: Confidence filtering
+    # conf shape is (V, H*W, 1); unsqueeze batch dim for filter_by_confidence
+    conf_b = conf.squeeze(-1)  # (V, H*W)
+    conf_batch = conf_b.unsqueeze(0)  # (1, V, H*W) — treat as B=1
+    mask_batch = filter_by_confidence(conf_batch, percentile=conf_percentile)
+    conf_mask = mask_batch[0]  # (V, H*W)
+
+    n_total = V * pointmaps.shape[1]
+    n_kept = conf_mask.sum().item()
+    print(
+        f"[visualize] Confidence filter ({conf_percentile:.0f}th percentile): "
+        f"{int(n_kept)}/{n_total} pixels kept "
+        f"({100.0 * n_kept / max(n_total, 1):.1f}%)"
+    )
+
+    # Step 4: Colors
+    focal_lengths = [
+        pose.get("focal_length", float(W)) for pose in poses
+    ]
+    # focal_length may not be present if pose came from cam2rig
+    focal_lengths = [
+        fl if isinstance(fl, (int, float)) and fl > 0 else float(W)
+        for fl in focal_lengths
+    ]
+
+    imgs_batch = imgs_b.unsqueeze(0)           # (1, V, 3, H, W)
+    conf_batch_full = conf_b.unsqueeze(0)      # (1, V, H*W)
+    colors_batch = compute_colors(
+        imgs_batch, conf_batch_full, cluster_labels, mode=color_mode, cmap_name=cmap_name
+    )
+    colors_v = colors_batch[0]  # (V, H*W, 3)
+
+    # Step 5: Build point cloud
+    pcd = build_point_cloud(pointmaps, conf_mask, colors_v, poses)
+    print(
+        f"[visualize] Point cloud: {len(pcd.points)} points, "
+        f"{V} views, color_mode='{color_mode}'"
+    )
+
+    # Step 6a: Camera frustums
+    frustums = []
+    if show_frustums:
+        frustums = build_all_frustums(
+            poses, cluster_labels, focal_lengths, (H, W), frustum_scale
+        )
+
+    # Step 6b: Ray visualization
+    rays = None
+    if show_rays:
+        rays = build_ray_visualization(
+            rig_raymap, n_samples=n_ray_samples, ray_length=ray_length
+        )
+
+    # Step 7: Export
+    if export_path is not None:
+        export_point_cloud(pcd, export_path)
+
+    # Step 8: Interactive viewer
+    if show:
+        geometries = [pcd] + frustums
+        if rays is not None:
+            geometries.append(rays)
+        coord_frame = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.3)
+        geometries.append(coord_frame)
+        o3d.visualization.draw_geometries(
+            geometries,
+            window_name="Rig3R Visualization",
+            width=1280,
+            height=720,
+        )
+
+    return {
+        "pcd": pcd,
+        "frustums": frustums,
+        "rays": rays,
+        "poses": poses,
+        "labels": cluster_labels,
+    }

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -6,9 +6,9 @@ raymaps, poses) into Open3D geometries, plus a top-level convenience function
 that runs the full pipeline.
 """
 
+import open3d as o3d  # must be imported before torch to avoid libstdc++ conflict
 import numpy as np
 import torch
-import open3d as o3d
 import matplotlib.cm as mpl_cm
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple


### PR DESCRIPTION
## Summary

- Adds `utils/visualization.py` with a full set of primitives for converting raw Rig3R model outputs (pointmaps, confidence, raymaps, poses) into Open3D geometry objects.
- Adds `scripts/visualize.py`, a standalone CLI that loads a dataset sequence, runs inference, and opens an interactive viewer or exports to `.ply`/`.pcd`.
- Adds `tests/test_visualization.py` with 23 unit and integration tests covering every function.
- Adds `docs/VISUALIZATION.md` with full usage instructions, CLI reference, and a step-by-step explanation of the pipeline.
- Updates `README.md` with a Visualization section linking to the new docs.

## What it visualizes
- Reconstructed 3D point cloud from confidence-filtered pointmaps, transformed to the global rig frame.
- Camera frustum overlays (one pyramid per view).
- Optional rig raymap ray segments for debugging predicted ray geometry.
- Four coloring modes: `rgb`, `per-camera`, `rig-cluster`, `confidence`.

## How rig-structure coloring works

When `--color-mode rig-cluster` is used, cameras are clustered by recovered pose using the existing `cluster_rig_poses` utility. Views in the same cluster share a color, making rig discovery results immediately visible without any extra tooling.

## Test plan
- [x] Run `pytest tests/test_visualization.py -v` — all 23 tests pass.
- [x] Run `python scripts/visualize.py --config configs/evaluate_mini.yaml --no-show --export personals/tmp/test.ply --device cpu` — script completes and produces a non-empty `.ply` file.
- [x] Run with `--color-mode rig-cluster --n-clusters 2` and confirm cluster summary is printed.
- [x] Run without `--no-show` on a machine with a display and confirm the Open3D viewer opens.