### PR TITLE
Log the training pipeline with Weights & Biases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ huggingface_hub>=0.36.0
 pandas>=2.3.3
 gdown>=5.2.0
 
-tensorboard>=2.20.0
+wandb>=0.19.0
 
 # PyTorch CUDA 13
 torch>=2.9.1

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,7 +23,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 from models.rig3r import Rig3R  
 
 # --- Optional: logging ---
-from torch.utils.tensorboard import SummaryWriter
+import wandb
 
 # -----------------------------
 # 1. Load configs
@@ -205,12 +205,20 @@ def unpack_batch(batch, device):
 # -----------------------------
 # 7. Logging setup
 # -----------------------------
-writer = SummaryWriter(log_dir="runs/rig3r_train")
+run = wandb.init(
+    project=train_cfg.get("wandb_project", "open-rig3r"),
+    entity=train_cfg.get("wandb_entity"),
+    name=train_cfg.get("wandb_run_name"),
+    mode=train_cfg.get("wandb_mode", "online"),  # "offline" / "disabled" for no network
+    config={**train_cfg, "config_file": args.config, "device": str(device)},
+    dir="runs",
+)
 
 # -----------------------------
 # 8. Training loop
 # -----------------------------
 num_epochs = train_cfg.get("epochs", 50)
+global_step = 0
 
 for epoch in range(num_epochs):
     model.train()
@@ -230,11 +238,12 @@ for epoch in range(num_epochs):
 
         running_loss += loss.item()
         train_bar.set_postfix({"loss": f"{loss.item():.4f}"})
+        wandb.log({"train/batch_loss": loss.item()}, step=global_step)
+        global_step += 1
 
     scheduler.step()
     avg_loss = running_loss / len(train_loader)
     print(f"Epoch [{epoch+1}/{num_epochs}] - Train Loss: {avg_loss:.4f}")
-    writer.add_scalar("Loss/train", avg_loss, epoch)
 
     # -----------------------------
     # 9. Validation loop
@@ -255,7 +264,16 @@ for epoch in range(num_epochs):
 
     avg_val_loss = val_loss / len(val_loader)
     print(f"Epoch [{epoch+1}/{num_epochs}] - Val Loss: {avg_val_loss:.4f}")
-    writer.add_scalar("Loss/val", avg_val_loss, epoch)
+
+    wandb.log(
+        {
+            "epoch": epoch + 1,
+            "train/loss": avg_loss,
+            "val/loss": avg_val_loss,
+            "lr": scheduler.get_last_lr()[0],
+        },
+        step=global_step,
+    )
 
     # -----------------------------
     # 10. Save checkpoints
@@ -265,5 +283,12 @@ for epoch in range(num_epochs):
         os.makedirs("checkpoints", exist_ok=True)
         torch.save(model.state_dict(), ckpt_path)
 
-writer.close()
+        artifact = wandb.Artifact(
+            f"rig3r-{run.id}", type="model",
+            metadata={"epoch": epoch + 1, "val_loss": avg_val_loss},
+        )
+        artifact.add_file(ckpt_path)
+        run.log_artifact(artifact, aliases=["latest", f"epoch-{epoch+1}"])
+
+run.finish()
 print("Training finished!")


### PR DESCRIPTION
## Summary

Training metrics went to TensorBoard event files under `runs/rig3r_train`, which
is gitignored and local to whatever machine the run happened on. Comparing two
runs meant copying event files around, and nothing recorded which config produced
which curve.

This PR swaps `SummaryWriter` for `wandb`, so every run carries its hyperparameters,
its loss curves, and its checkpoints in one place.

## Changes

### `scripts/train.py`

`from torch.utils.tensorboard import SummaryWriter` → `import wandb`.

**Run init** replaces the `SummaryWriter` construction:

```python
run = wandb.init(
    project=train_cfg.get("wandb_project", "open-rig3r"),
    entity=train_cfg.get("wandb_entity"),
    name=train_cfg.get("wandb_run_name"),
    mode=train_cfg.get("wandb_mode", "online"),
    config={**train_cfg, "config_file": args.config, "device": str(device)},
    dir="runs",
)
```

All four settings are read from the training config with working defaults, so the
existing configs run unchanged. The whole `train_cfg` dict is logged as the run
config — batch size, `n_frames`, optimizer and scheduler settings, dataset type —
plus the config file path and the resolved device, so a run in the UI is traceable
back to the exact YAML that produced it.

`dir="runs"` keeps wandb's local state inside the already-gitignored `runs/`.

**Metrics logged:**

| Key | Frequency | Notes |
| --- | --- | --- |
| `train/batch_loss` | every batch | same value the tqdm postfix shows |
| `train/loss` | every epoch | mean over the epoch |
| `val/loss` | every epoch | mean over the validation loader |
| `lr` | every epoch | `scheduler.get_last_lr()[0]`, post-step |
| `epoch` | every epoch | 1-indexed, matches the printed lines |

A `global_step` counter drives every `wandb.log` call. Epoch metrics are logged on
the same step as the last batch of that epoch, so the per-batch and per-epoch
curves share one x-axis instead of drifting apart. The previous TensorBoard code
only logged the two per-epoch scalars.

**Checkpoints as artifacts.** The existing every-5-epochs `torch.save` now also
uploads the file:

```python
artifact = wandb.Artifact(
    f"rig3r-{run.id}", type="model",
    metadata={"epoch": epoch + 1, "val_loss": avg_val_loss},
)
artifact.add_file(ckpt_path)
run.log_artifact(artifact, aliases=["latest", f"epoch-{epoch+1}"])
```

Artifacts dedupe by content hash, and the `latest` / `epoch-N` aliases give
downstream eval a stable handle. `writer.close()` becomes `run.finish()`, so a run
that completes is marked `finished` rather than left hanging as `running`.

### `requirements.txt`

`tensorboard>=2.20.0` → `wandb>=0.19.0`. Nothing else in the repo imported
tensorboard, so the dependency is a straight swap rather than an addition.

## Usage

```bash
wandb login          # once per machine
make train
```

To point a run at a different project or name it, add to the training config:

```yaml
wandb_project: open-rig3r
wandb_entity: my-team       # optional
wandb_run_name: waymo-5cam-baseline
wandb_mode: online          # offline | disabled
```

On a node without outbound network, set `wandb_mode: offline` and upload afterwards:

```bash
wandb sync runs/wandb/offline-run-*
```

`wandb_mode: disabled` makes every wandb call a no-op, which is the setting to use
if training is invoked from a test.

## Testing

Verified the logging path end to end with `mode="disabled"` — init with a real
config, per-batch and per-epoch logs on a shared step counter, artifact creation
with aliases, and `finish()`. No network and no credentials required.

A full `make train` run was not exercised here; the training loop itself is
unchanged apart from the log calls.