### PR TITLE
Supervise the pointmap head with Waymo lidar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ setup-train:
 download-waymo-full:
 	sh ops/get_waymo_data_full.sh
 	python ops/parquet2jpeg.py --src /data/waymo --dst /data/waymo
+	python ops/parquet2pointmap.py --src /data/waymo --dst /data/waymo
 
 download-waymo-mini:
 	sh ops/get_waymo_data_mini.sh
 	python ops/parquet2jpeg.py --src /data/waymo_mini --dst /data/waymo_mini
+	python ops/parquet2pointmap.py --src /data/waymo_mini --dst /data/waymo_mini
 
 download-wayve101:
 	mkdir -p data/wayve_scenes_101

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -12,6 +12,13 @@ n_frames: 24  # consecutive timestamps per sample; views = n_frames * num_camera
 image_size: [128, 128]
 patch_size: 8  # must match the model; also sets the raymap target resolution
 
+# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
+# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+loss:
+  w_point: 1.0
+  w_pose: 1.0
+  w_rig: 1.0
+
 # Optimizer configuration
 optimizer:
   lr: 0.0001

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -12,6 +12,13 @@ n_frames: 2  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
 patch_size: 8  # must match the model; also sets the raymap target resolution
 
+# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
+# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+loss:
+  w_point: 1.0
+  w_pose: 1.0
+  w_rig: 1.0
+
 # Optimizer configuration
 optimizer:
   lr: 0.0001

--- a/datasets/waymo.py
+++ b/datasets/waymo.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
+import numpy
 import torch
 from PIL import Image
 from torch.utils.data import Dataset
@@ -71,14 +72,22 @@ class WaymoDataset(Dataset):
         # segment name -> per-camera geometry, static for the whole segment
         self.cam2rig: Dict[str, torch.Tensor] = {}  # (n_cameras, 4, 4)
         self.intrinsics: Dict[str, torch.Tensor] = {}  # (n_cameras, 4)
-        # segment name -> {timestamp: world_from_rig (4, 4)}
-        self.poses: Dict[str, Dict[str, torch.Tensor]] = {}
+        # segment name -> {timestamp: {camera: world_from_rig (4, 4)}}
+        self.poses: Dict[str, Dict[str, Dict[str, torch.Tensor]]] = {}
+        # segment name -> ({timestamp: row}, {camera: memmapped (n_frames, G, G, 3)})
+        self.pointmaps: Dict[str, Tuple[Dict[str, int], Dict[str, numpy.ndarray]]] = {}
         for segment in segments:
             timestamps = self._shared_timestamps(segment)
             if not timestamps:
                 continue  # incomplete rig
             poses = self._load_poses(segment)
             timestamps = [t for t in timestamps if t in poses]
+
+            pointmaps = self._load_pointmaps(segment)
+            if pointmaps is not None:
+                self.pointmaps[segment.name] = pointmaps
+                timestamps = [t for t in timestamps if t in pointmaps[0]]
+
             if not timestamps:
                 continue
             self.cam2rig[segment.name], self.intrinsics[segment.name] = (
@@ -125,17 +134,20 @@ class WaymoDataset(Dataset):
         cam2rig = self.cam2rig[segment.name].repeat(n_frames, 1, 1)
         intrinsics = self.intrinsics[segment.name].repeat(n_frames, 1)
 
-        # the rig moves, so world_from_rig is per timestamp, held across the cameras
+        # the rig moves and each camera fires at its own instant, so this is per view
         poses = self.poses[segment.name]
-        world_from_rig = torch.stack(
-            [poses[timestamp] for timestamp in timestamps]
-        ).repeat_interleave(len(self.cameras), dim=0)
+        world_from_rig = torch.stack([
+            poses[timestamp][camera]
+            for timestamp in timestamps
+            for camera in self.cameras
+        ])
 
         return {
             "images": images,
             "metadata": {"cam2rig": cam2rig},  # (n_frames * n_cameras, 4, 4)
             "intrinsics": intrinsics,  # (n_frames * n_cameras, 4)
             "world_from_rig": world_from_rig,  # (n_frames * n_cameras, 4, 4)
+            "pointmap": self._pointmap(segment, timestamps),
             "pointcloud": torch.empty(0, 3),
             "segment_id": segment.name,
             "timestamps": [int(t) for t in timestamps],
@@ -182,8 +194,8 @@ class WaymoDataset(Dataset):
             torch.tensor(intrinsics, dtype=torch.float32),
         )
 
-    def _load_poses(self, segment: Path) -> Dict[str, torch.Tensor]:
-        """world_from_rig SE(3) per frame timestamp."""
+    def _load_poses(self, segment: Path) -> Dict[str, Dict[str, torch.Tensor]]:
+        """world_from_rig SE(3) per frame timestamp, per camera capture instant."""
         poses_file = segment / "poses.json"
         if not poses_file.exists():
             raise ValueError(
@@ -191,10 +203,52 @@ class WaymoDataset(Dataset):
                 f"Re-run `python ops/parquet2jpeg.py` to export it alongside the images."
             )
 
+        poses = json.loads(poses_file.read_text())
         return {
-            timestamp: torch.tensor(transform, dtype=torch.float32).reshape(4, 4)
-            for timestamp, transform in json.loads(poses_file.read_text()).items()
+            timestamp: {
+                camera: torch.tensor(transform, dtype=torch.float32).reshape(4, 4)
+                for camera, transform in cameras.items()
+            }
+            for timestamp, cameras in poses.items()
+            if all(camera in cameras for camera in self.cameras)
         }
+
+    def _load_pointmaps(self, segment: Path):
+        """({timestamp: row}, {camera: memmapped array}), or None if not exported.
+
+        Optional on purpose: without it training still runs on raymap supervision
+        alone, which is what every tree exported before ops/parquet2pointmap.py has.
+        """
+        directory = segment / "pointmap"
+        if not directory.is_dir():
+            return None
+
+        timestamps = json.loads((directory / "timestamps.json").read_text())
+        arrays = {
+            camera: numpy.load(directory / f"{camera}.npy", mmap_mode="r")
+            for camera in self.cameras
+        }
+        return {timestamp: row for row, timestamp in enumerate(timestamps)}, arrays
+
+    def _pointmap(self, segment: Path, timestamps: List[str]) -> torch.Tensor:
+        """Sparse lidar pointmap per view, in that view's own camera frame.
+
+        (n_frames * n_cameras, grid, grid, 3), NaN where no lidar return landed.
+        Empty (0, 0, 0, 3) when the segment has no pointmap export, so training
+        falls back to raymap-only supervision instead of failing.
+        """
+        grids = self.pointmaps.get(segment.name)
+        if grids is None:
+            return torch.empty(0, 0, 0, 3)
+
+        rows, arrays = grids
+        return torch.from_numpy(
+            numpy.stack([
+                arrays[camera][rows[timestamp]]
+                for timestamp in timestamps
+                for camera in self.cameras
+            ])
+        ).float()
 
     def get_sequence_ids(self) -> List[str]:
         """Returns the segment IDs actually indexed, in order, without duplicates."""

--- a/docs/DATA_PREP.md
+++ b/docs/DATA_PREP.md
@@ -62,6 +62,8 @@ Output layout:
 <dst>/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
 <dst>/<split>/<segment>/calibration.json
 <dst>/<split>/<segment>/poses.json
+<dst>/<split>/<segment>/pointmap/<CAMERA>.npy      # from parquet2pointmap.py
+<dst>/<split>/<segment>/pointmap/timestamps.json
 ```
 
 with `<CAMERA>` one of `FRONT`, `FRONT_LEFT`, `FRONT_RIGHT`, `SIDE_LEFT`, `SIDE_RIGHT`.
@@ -72,19 +74,53 @@ Re-running overwrites existing files in place.
 frame) plus `f_u`/`f_v`/`c_u`/`c_v` and native `width`/`height`. Intrinsics are
 stored unscaled; `WaymoDataset` rescales them to `image_size` on load.
 
-`poses.json` maps each frame timestamp to a 4x4 `world_from_vehicle`. Without it
-every frame's rays would be identical and pose supervision would be degenerate,
-so the loader skips timestamps that have no pose.
+`poses.json` maps each frame timestamp to a 4x4 `world_from_vehicle` **per camera**,
+taken at that camera's own trigger instant rather than once per frame. The five
+cameras do not fire together, so a single per-frame pose leaves points tens of
+pixels off their own camera's rays whenever the rig is moving.
 
 Both files are required: `WaymoDataset` raises if either is missing, and a tree
 exported before they existed needs a re-run.
 
 Together they are what supervises training — `utils/raymap.py` turns calibration
 plus poses into the `rig_raymap` and `pose_raymap` targets that `MultiTaskLoss`
-scores. Pointmap supervision still needs the `lidar` component and is skipped for
-now, so only two of the three loss terms are active on Waymo.
+scores.
 
-### 5. Point the training config at it
+### 5. The lidar pointmaps
+
+`ops/parquet2pointmap.py` adds the third loss term, projecting the TOP lidar into
+each camera to get sparse depth. The `make` targets run it; run it directly to
+re-export:
+
+```bash
+python ops/parquet2pointmap.py --src data/waymo_mini --dst /data/waymo_mini
+python ops/parquet2pointmap.py --src data/waymo_mini --verify
+```
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--src` | `data/waymo_mini` | Root of the downloaded parquet dataset |
+| `--dst` | `/data/waymo_mini` | Where to write the pointmaps |
+| `--splits` | `train validation` | Splits to convert |
+| `--grid` | `64` | Cells per side, pooled to the patch grid at load |
+| `--verify` | off | Reproject against Waymo's own projections instead of writing |
+
+Each `<CAMERA>.npy` is `(n_frames, grid, grid, 3)` float16 holding points in that
+camera's own frame, `NaN` where no return landed, about 24 MB per segment. The
+loader pools the grid down to the model's patch grid and turns coverage into
+`pointmap_conf`, so empty patches contribute nothing to the loss.
+
+Unlike the other two files this one is **optional** — without it training still
+runs on raymap supervision alone.
+
+`--verify` is the check on the range-image math: it reprojects the computed points
+through the camera intrinsics and compares against the `lidar_camera_projection`
+component. Expect a median around 2 px at native 1920x1280 resolution. The residual
+is per-row rolling shutter, which needs the `velocity` and `rolling_shutter_params`
+fields to model; at 128x128 training resolution even the worst observed segment
+stays under half a patch, so it is left uncorrected.
+
+### 6. Point the training config at it
 
 `waymo_path` in [`configs/train_waymo.yaml`](../configs/train_waymo.yaml) must match
 your `--dst`:

--- a/ops/parquet2jpeg.py
+++ b/ops/parquet2jpeg.py
@@ -37,7 +37,8 @@ CALIB_COLS = [
 
 POSE_COLS = [
     "key.frame_timestamp_micros",
-    "[VehiclePoseComponent].world_from_vehicle.transform",
+    "key.camera_name",
+    "[CameraImageComponent].pose.transform",
 ]
 
 
@@ -71,21 +72,27 @@ def convert_calibration(src, dst, split):
 
 
 def convert_poses(src, dst, split):
-    """Write one poses.json per segment: world_from_vehicle 4x4 per frame timestamp.
+    """Write one poses.json per segment: {timestamp: {camera: world_from_vehicle 4x4}}.
 
     This is what makes rays from different frames comparable, so pose supervision
     is not just the static rig repeated.
+
+    It is keyed per camera, not per frame, because the five cameras are triggered
+    at different instants within a frame - `vehicle_pose` holds one pose for the
+    whole frame, which leaves points tens of pixels off their own camera's rays
+    while the rig is moving. Reading the pose column skips the image bytes.
     """
-    files = sorted((src / split / "vehicle_pose").glob("*.parquet"))
+    files = sorted((src / split / "camera_image").glob("*.parquet"))
 
     for path in tqdm(files, desc=f"{split} poses"):
         rows = pq.read_table(path, columns=POSE_COLS).to_pylist()
-        poses = {
-            str(row["key.frame_timestamp_micros"]): row[
-                "[VehiclePoseComponent].world_from_vehicle.transform"
+        poses = {}
+        for row in rows:
+            timestamp = str(row["key.frame_timestamp_micros"])
+            camera = CAMERAS.get(row["key.camera_name"], f"CAMERA_{row['key.camera_name']}")
+            poses.setdefault(timestamp, {})[camera] = row[
+                "[CameraImageComponent].pose.transform"
             ]
-            for row in rows
-        }
 
         out_dir = dst / split / path.stem
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/ops/parquet2pointmap.py
+++ b/ops/parquet2pointmap.py
@@ -1,0 +1,269 @@
+"""Project Waymo TOP lidar into each camera -> per-frame sparse pointmaps.
+
+Layout: DST/<split>/<segment>/pointmap/<CAMERA>.npy   (n_frames, grid, grid, 3) float16
+        DST/<split>/<segment>/pointmap/timestamps.json
+
+Points are stored in each camera's *own* frame, with NaN where no lidar return
+landed in that cell. Per-camera is the only frame that is consistent: the five
+cameras are triggered at different times within a frame and the lidar spins
+across it, so a single shared vehicle frame leaves points off their own camera's
+rays by tens of pixels whenever the rig is moving. The loader re-expresses them
+relative to whichever view a training window starts at.
+
+`--verify` skips writing and instead reprojects the computed points back through
+the camera intrinsics, comparing against Waymo's own `lidar_camera_projection`.
+That is the check on the range-image math: if the geometry is wrong, the
+reprojection error blows up.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+from tqdm import tqdm
+
+SPLITS = ["train", "validation"]
+
+# waymo CameraName enum, matching ops/parquet2jpeg.py
+CAMERAS = {1: "FRONT", 2: "FRONT_LEFT", 3: "FRONT_RIGHT", 4: "SIDE_LEFT", 5: "SIDE_RIGHT"}
+
+# ponytail: TOP lidar only. It is the 64-beam 360-degree sensor covering every
+# camera out to ~75m; the four side lidars are 20m near-field and use a different
+# (min/max) inclination convention. Add them if close-range density matters.
+TOP = 1
+
+
+def rotation_matrix(roll, pitch, yaw):
+    """ZYX euler -> (..., 3, 3), matching waymo's transform_utils.get_rotation_matrix."""
+    cos_roll, sin_roll = np.cos(roll), np.sin(roll)
+    cos_pitch, sin_pitch = np.cos(pitch), np.sin(pitch)
+    cos_yaw, sin_yaw = np.cos(yaw), np.sin(yaw)
+    zeros, ones = np.zeros_like(cos_roll), np.ones_like(cos_roll)
+
+    shape = cos_roll.shape + (3, 3)
+    r_roll = np.stack([ones, zeros, zeros, zeros, cos_roll, -sin_roll,
+                       zeros, sin_roll, cos_roll], -1).reshape(shape)
+    r_pitch = np.stack([cos_pitch, zeros, sin_pitch, zeros, ones, zeros,
+                        -sin_pitch, zeros, cos_pitch], -1).reshape(shape)
+    r_yaw = np.stack([cos_yaw, -sin_yaw, zeros, sin_yaw, cos_yaw, zeros,
+                      zeros, zeros, ones], -1).reshape(shape)
+    return r_yaw @ r_pitch @ r_roll
+
+
+def transform(points, matrix):
+    """Apply a 4x4 SE(3) to (..., 3) points."""
+    return points @ matrix[:3, :3].T + matrix[:3, 3]
+
+
+def range_image_to_world(range_image, extrinsic, inclinations, pixel_pose):
+    """Range image -> cartesian points in the world frame.
+
+    The TOP lidar spins during the frame, so each pixel carries its own vehicle
+    pose. Points go sensor -> vehicle(pixel time) -> world, which is what removes
+    the rolling-shutter smear. World is the only frame shared by every sensor, so
+    the per-camera step downstream can pick up each camera's own capture time.
+    """
+    height, width, _ = range_image.shape
+
+    # azimuth runs backwards across the image and is offset by the sensor yaw
+    azimuth_correction = np.arctan2(extrinsic[1, 0], extrinsic[0, 0])
+    ratios = (np.arange(width, 0, -1) - 0.5) / width
+    azimuth = ((ratios * 2.0 - 1.0) * np.pi - azimuth_correction)[None, :]
+    inclination = inclinations[:, None]
+
+    ranges = range_image[..., 0]
+    points = np.stack([
+        np.cos(azimuth) * np.cos(inclination) * ranges,
+        np.sin(azimuth) * np.cos(inclination) * ranges,
+        np.sin(inclination) * ranges,
+    ], axis=-1)
+
+    points = transform(points, extrinsic)
+
+    pixel_rotation = rotation_matrix(pixel_pose[..., 0], pixel_pose[..., 1], pixel_pose[..., 2])
+    world = np.einsum("hwij,hwj->hwi", pixel_rotation, points) + pixel_pose[..., 3:]
+
+    return world, ranges
+
+
+def bin_to_grid(points, ranges, pixels, size, grid):
+    """Scatter projected points into a (grid, grid, 3) cell map, nearest return wins."""
+    width, height = size
+    cells = np.stack([
+        np.clip(pixels[:, 1] / height * grid, 0, grid - 1),
+        np.clip(pixels[:, 0] / width * grid, 0, grid - 1),
+    ], -1).astype(np.int32)
+
+    # writing far points first leaves the nearest surface in each cell
+    order = np.argsort(-ranges)
+    flat = np.full((grid * grid, 3), np.nan, dtype=np.float32)
+    flat[cells[order, 0] * grid + cells[order, 1]] = points[order]
+    return flat.reshape(grid, grid, 3)
+
+
+def camera_calibration(src, split, segment):
+    """{camera_name: (cam2rig, intrinsics, (width, height))}"""
+    table = pq.read_table(f"{src}/{split}/camera_calibration/{segment}.parquet").to_pylist()
+    prefix = "[CameraCalibrationComponent]"
+    return {
+        row["key.camera_name"]: (
+            np.array(row[f"{prefix}.extrinsic.transform"]).reshape(4, 4),
+            np.array([row[f"{prefix}.intrinsic.{k}"] for k in ("f_u", "f_v", "c_u", "c_v")]),
+            (row[f"{prefix}.width"], row[f"{prefix}.height"]),
+        )
+        for row in table
+    }
+
+
+def project(camera_points, intrinsics):
+    """Camera-frame points -> pixels, Waymo camera model (x forward, y left, z up)."""
+    f_u, f_v, c_u, c_v = intrinsics
+    u = f_u * (-camera_points[:, 1] / camera_points[:, 0]) + c_u
+    v = f_v * (-camera_points[:, 2] / camera_points[:, 0]) + c_v
+    return np.stack([u, v], -1)
+
+
+def read_camera_poses(src, split, segment):
+    """{(timestamp, camera_name): world_from_vehicle at that camera's capture time}.
+
+    Each camera is triggered at its own instant, so this is not the frame's
+    vehicle pose. Reading it skips the image column, so it stays cheap.
+    """
+    table = pq.read_table(
+        f"{src}/{split}/camera_image/{segment}.parquet",
+        columns=["key.frame_timestamp_micros", "key.camera_name",
+                 "[CameraImageComponent].pose.transform"],
+    ).to_pylist()
+    return {
+        (row["key.frame_timestamp_micros"], row["key.camera_name"]): np.array(
+            row["[CameraImageComponent].pose.transform"]
+        ).reshape(4, 4)
+        for row in table
+    }
+
+
+def read_top_frames(src, split, component, prefix, segment):
+    """{timestamp: range image array} for the TOP laser only."""
+    path = f"{src}/{split}/{component}/{segment}.parquet"
+    columns = ["key.frame_timestamp_micros", f"{prefix}.range_image_return1.values",
+               f"{prefix}.range_image_return1.shape"]
+    if component != "lidar_pose":
+        columns.insert(0, "key.laser_name")
+
+    parquet = pq.ParquetFile(path)
+    frames = {}
+    for group in range(parquet.metadata.num_row_groups):
+        table = parquet.read_row_group(group, columns=columns)
+        lasers = table.column("key.laser_name").to_pylist() if "key.laser_name" in columns else None
+        timestamps = table.column("key.frame_timestamp_micros").to_pylist()
+        values = table.column(f"{prefix}.range_image_return1.values")
+        shapes = table.column(f"{prefix}.range_image_return1.shape").to_pylist()
+
+        for i, timestamp in enumerate(timestamps):
+            if lasers is not None and lasers[i] != TOP:
+                continue
+            frames[timestamp] = np.asarray(values[i].values).reshape(shapes[i])
+    return frames
+
+
+def convert_segment(src, dst, split, segment, grid, verify):
+    calibration = pq.read_table(f"{src}/{split}/lidar_calibration/{segment}.parquet").to_pylist()
+    prefix = "[LiDARCalibrationComponent]"
+    top = next(row for row in calibration if row["key.laser_name"] == TOP)
+    extrinsic = np.array(top[f"{prefix}.extrinsic.transform"]).reshape(4, 4)
+    # range image row 0 is the topmost beam, so the stored inclinations are reversed
+    inclinations = np.array(top[f"{prefix}.beam_inclination.values"])[::-1]
+
+    poses = read_camera_poses(src, split, segment)
+    cameras = camera_calibration(src, split, segment)
+
+    lidar = read_top_frames(src, split, "lidar", "[LiDARComponent]", segment)
+    pixel_poses = read_top_frames(src, split, "lidar_pose", "[LiDARPoseComponent]", segment)
+    projections = read_top_frames(
+        src, split, "lidar_camera_projection", "[LiDARCameraProjectionComponent]", segment
+    )
+
+    timestamps = sorted(
+        t for t in lidar
+        if t in pixel_poses and t in projections
+        and all((t, camera_name) in poses for camera_name in CAMERAS)
+    )
+    pointmaps = {name: [] for name in CAMERAS.values()}
+    errors = {name: [] for name in CAMERAS.values()}
+
+    for timestamp in timestamps:
+        world, ranges = range_image_to_world(
+            lidar[timestamp], extrinsic, inclinations, pixel_poses[timestamp]
+        )
+        projection = projections[timestamp]
+        valid = ranges > 0
+
+        for camera_name, name in CAMERAS.items():
+            cam2rig, intrinsics, size = cameras[camera_name]
+            # each return may project into up to two cameras
+            hits = [
+                (projection[..., 0] == camera_name) & valid,
+                (projection[..., 3] == camera_name) & valid,
+            ]
+            selected = np.concatenate([world[hit] for hit in hits])
+            pixels = np.concatenate(
+                [projection[..., 1:3][hits[0]], projection[..., 4:6][hits[1]]]
+            )
+            depths = np.concatenate([ranges[hit] for hit in hits])
+
+            # world -> vehicle at this camera's capture time -> camera
+            world_from_camera = poses[(timestamp, camera_name)] @ cam2rig
+            selected = transform(selected, np.linalg.inv(world_from_camera))
+
+            if verify:
+                if len(selected):
+                    reprojected = project(selected, intrinsics)
+                    errors[name].append(np.linalg.norm(reprojected - pixels, axis=-1))
+                continue
+
+            pointmaps[name].append(bin_to_grid(selected, depths, pixels, size, grid))
+
+    if verify:
+        for name, batch in errors.items():
+            stacked = np.concatenate(batch)
+            print(f"  {name:12s} n={len(stacked):8d}  median={np.median(stacked):6.2f}px  "
+                  f"p99={np.percentile(stacked, 99):7.2f}px")
+        return
+
+    out_dir = dst / split / segment / "pointmap"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, frames in pointmaps.items():
+        np.save(out_dir / f"{name}.npy", np.stack(frames).astype(np.float16))
+    (out_dir / "timestamps.json").write_text(json.dumps([str(t) for t in timestamps]))
+
+
+def convert_split(src, dst, split, grid, verify):
+    segments = sorted(p.stem for p in (src / split / "lidar").glob("*.parquet"))
+    for segment in tqdm(segments, desc=f"{split} pointmaps"):
+        if verify:
+            print(f"\n{segment}")
+        convert_segment(str(src), dst, split, segment, grid, verify)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", type=Path, default=Path("data/waymo_mini"),
+                        help="Root of the downloaded parquet dataset (default: %(default)s)")
+    parser.add_argument("--dst", type=Path, default=Path("/data/waymo_mini"),
+                        help="Where to write the pointmaps (default: %(default)s)")
+    parser.add_argument("--splits", nargs="+", default=SPLITS,
+                        help="Splits to convert (default: %(default)s)")
+    parser.add_argument("--grid", type=int, default=64,
+                        help="Cells per side, pooled down to the patch grid at load "
+                             "(default: %(default)s)")
+    parser.add_argument("--verify", action="store_true",
+                        help="Reproject against waymo's own projections instead of writing")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    for split in args.splits:
+        convert_split(args.src, args.dst, split, args.grid, args.verify)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,7 +22,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 # --- Import model ---
 from models.rig3r import Rig3R
 from models.losses import MultiTaskLoss
-from utils.raymap import build_raymap_targets
+from utils.raymap import build_pointmap_target, build_raymap_targets
 
 # --- Optional: logging ---
 import wandb
@@ -148,7 +148,14 @@ scheduler = CosineAnnealingLR(optimizer,
 # -----------------------------
 # 5. Loss function
 # -----------------------------
-criterion = MultiTaskLoss()
+# the pointmap term is a metric MSE in metres and runs an order of magnitude above
+# the two raymap terms, which are cosine-based and bounded by 2 - hence the weights
+loss_cfg = train_cfg.get("loss", {})
+criterion = MultiTaskLoss(
+    w_point=loss_cfg.get("w_point", 1.0),
+    w_pose=loss_cfg.get("w_pose", 1.0),
+    w_rig=loss_cfg.get("w_rig", 1.0),
+)
 
 
 def downsample_pointmap(pointmap, img_size, patch_size):
@@ -181,9 +188,20 @@ def compute_loss(outputs, batch, device, img_size, patch_size):
     targets = {}
 
     pointcloud = batch["pointcloud"].to(device)
+    pointmap = batch.get("pointmap", torch.empty(0)).to(device)
+
     if pointcloud.numel() > 0:
         preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
         targets["pointmap"] = pointcloud
+    elif pointmap.numel() > 0:
+        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
+        targets["pointmap"], targets["pointmap_conf"] = build_pointmap_target(
+            pointmap=pointmap,
+            cam2rig=batch["metadata"]["cam2rig"].to(device),
+            world_from_rig=batch["world_from_rig"].to(device),
+            patch_size=patch_size,
+            image_size=img_size,
+        )
 
     if "intrinsics" in batch:
         targets.update(build_raymap_targets(

--- a/tests/test_raymap.py
+++ b/tests/test_raymap.py
@@ -7,7 +7,13 @@ import torch
 root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
-from utils.raymap import build_raymap_targets, camera_ray_directions, patch_centers
+from utils.raymap import (
+    build_pointmap_target,
+    build_raymap_targets,
+    camera_ray_directions,
+    patch_centers,
+    reference_from_camera,
+)
 
 
 IMAGE_SIZE = (128, 128)
@@ -146,6 +152,92 @@ def test_pose_raymap_sees_rig_rotation():
     print("✓ test_pose_raymap_sees_rig_rotation passed")
 
 
+def test_pointmap_pools_to_patch_grid():
+    """Export grid is coarser than the model's patch grid, so it must pool down"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=1)
+    export_grid = GRID * 2
+    pointmap = torch.full((1, 1, export_grid, export_grid, 3), 3.0)
+
+    points, confidence = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert points.shape == (1, 1, P, 3), f"Got {tuple(points.shape)}"
+    assert confidence.shape == (1, 1, P), f"Got {tuple(confidence.shape)}"
+    assert torch.allclose(points, torch.full((1, 1, P, 3), 3.0)), "Pooling changed the values"
+    assert torch.allclose(confidence, torch.ones(1, 1, P)), "Fully covered patches should be 1"
+    print("✓ test_pointmap_pools_to_patch_grid passed")
+
+
+def test_pointmap_confidence_tracks_coverage():
+    """Empty cells must not be averaged in as zeros, or every target drifts toward 0"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=1)
+    export_grid = GRID * 2
+    pointmap = torch.full((1, 1, export_grid, export_grid, 3), torch.nan)
+    # fill one cell of each 2x2 block with a real return
+    pointmap[:, :, ::2, ::2] = 4.0
+    # and leave one whole patch completely empty
+    pointmap[:, :, 0:2, 0:2] = torch.nan
+
+    points, confidence = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert confidence[0, 0, 0] == 0.0, "The empty patch should have zero confidence"
+    assert torch.allclose(points[0, 0, 0], torch.zeros(3)), "Empty patches should be zeroed"
+    assert torch.allclose(confidence[0, 0, 1], torch.tensor(0.25)), (
+        f"One of four cells covered should be 0.25, got {confidence[0, 0, 1]}"
+    )
+    assert torch.allclose(points[0, 0, 1], torch.full((3,), 4.0)), (
+        f"Covered cell should survive averaging, got {points[0, 0, 1]}"
+    )
+    print("✓ test_pointmap_confidence_tracks_coverage passed")
+
+
+def test_pointmap_moves_into_reference_frame():
+    """Points arrive in each camera's own frame and must land in view 0's"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=2)
+    world_from_rig[0, 1, :3, 3] = torch.tensor([4.0, 0.0, 0.0])  # view 1 is 4 m ahead
+
+    pointmap = torch.full((1, 2, GRID, GRID, 3), 0.0)
+    pointmap[..., 0] = 10.0  # both views see something 10 m down their own +x
+
+    points, _ = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert torch.allclose(points[0, 0, :, 0], torch.full((P,), 10.0)), "View 0 is the reference"
+    assert torch.allclose(points[0, 1, :, 0], torch.full((P,), 14.0)), (
+        f"View 1's point should be 14 m out in view 0's frame, got {points[0, 1, 0]}"
+    )
+    print("✓ test_pointmap_moves_into_reference_frame passed")
+
+
+def test_pointmap_lies_along_its_own_rays():
+    """The end-to-end invariant: a target point sits on the ray of its own patch"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    cam2rig[0, 1, :3, 3] = torch.tensor([0.0, 1.0, 0.0])  # view 1 mounted a metre left
+    world_from_rig[0, 1, :3, 3] = torch.tensor([2.0, 0.0, 0.0])
+
+    # place a point 12 m along each patch's own camera ray
+    directions = camera_ray_directions(intrinsics, IMAGE_SIZE, PATCH_SIZE)
+    pointmap = (directions * 12.0).reshape(1, 2, GRID, GRID, 3)
+
+    points, _ = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+
+    centers = reference_from_camera(cam2rig, world_from_rig)[..., :3, 3]
+    for view in range(2):
+        offset = points[0, view] - centers[0, view]
+        cosine = torch.nn.functional.cosine_similarity(
+            offset, targets["pose_raymap"][0, view], dim=-1
+        )
+        assert cosine.min() > 0.9999, f"View {view} points drift off their rays: {cosine.min()}"
+    print("✓ test_pointmap_lies_along_its_own_rays passed")
+
+
 def run_all_tests():
     tests = [
         test_patch_centers_are_row_major,
@@ -155,6 +247,10 @@ def run_all_tests():
         test_rig_rotation_is_applied,
         test_pose_raymap_is_relative_to_first_view,
         test_pose_raymap_sees_rig_rotation,
+        test_pointmap_pools_to_patch_grid,
+        test_pointmap_confidence_tracks_coverage,
+        test_pointmap_moves_into_reference_frame,
+        test_pointmap_lies_along_its_own_rays,
     ]
 
     passed = 0

--- a/tests/test_waymo.py
+++ b/tests/test_waymo.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 import traceback
 
+import numpy
 import torch
 from PIL import Image
 
@@ -37,6 +38,18 @@ def mock_world_from_rig(index):
     return transform
 
 
+POINTMAP_GRID = 8
+
+
+def mock_pointmap():
+    """(n_timestamps, G, G, 3) with the bottom half empty, as lidar tends to be."""
+    grid = numpy.full(
+        (len(TIMESTAMPS), POINTMAP_GRID, POINTMAP_GRID, 3), numpy.nan, dtype=numpy.float16
+    )
+    grid[:, : POINTMAP_GRID // 2] = 5.0
+    return grid
+
+
 def create_mock_waymo_dataset(tmp_path):
     """
     Creates a minimal mock waymo JPEG tree for testing.
@@ -66,10 +79,20 @@ def create_mock_waymo_dataset(tmp_path):
             (segment_dir / "calibration.json").write_text(json.dumps(calibration))
 
             poses = {
-                str(timestamp): mock_world_from_rig(i).flatten().tolist()
+                str(timestamp): {
+                    camera: mock_world_from_rig(i).flatten().tolist() for camera in CAMERAS
+                }
                 for i, timestamp in enumerate(TIMESTAMPS)
             }
             (segment_dir / "poses.json").write_text(json.dumps(poses))
+
+            pointmap_dir = segment_dir / "pointmap"
+            pointmap_dir.mkdir(exist_ok=True)
+            for camera in CAMERAS:
+                numpy.save(pointmap_dir / f"{camera}.npy", mock_pointmap())
+            (pointmap_dir / "timestamps.json").write_text(
+                json.dumps([str(timestamp) for timestamp in TIMESTAMPS])
+            )
 
     return tmp_path
 
@@ -183,6 +206,35 @@ def test_world_from_rig_is_per_frame(mock_data):
     displacement = world_from_rig[n_cameras, 0, 3] - world_from_rig[0, 0, 3]
     assert displacement != 0, "Rig pose should differ between frames, or pose targets are static"
     print("✓ test_world_from_rig_is_per_frame passed")
+
+
+@with_mock_dataset
+def test_pointmap_is_loaded_per_view(mock_data):
+    """Lidar pointmaps line up one-per-view and keep their empty cells as NaN"""
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    pointmap = dataset[0]["pointmap"]
+
+    n_views = 2 * len(CAMERAS)
+    assert pointmap.shape == (n_views, POINTMAP_GRID, POINTMAP_GRID, 3), (
+        f"Got {tuple(pointmap.shape)}"
+    )
+    assert torch.isnan(pointmap[:, POINTMAP_GRID // 2 :]).all(), "Empty cells should stay NaN"
+    assert not torch.isnan(pointmap[:, : POINTMAP_GRID // 2]).any(), "Filled cells lost"
+    print("✓ test_pointmap_is_loaded_per_view passed")
+
+
+@with_mock_dataset
+def test_pointmap_is_optional(mock_data):
+    """A tree exported before lidar support still loads, just without pointmaps"""
+    for path in mock_data.glob("train/*/pointmap"):
+        shutil.rmtree(path)
+
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    sample = dataset[0]
+
+    assert sample["pointmap"].numel() == 0, "Missing pointmaps should give an empty tensor"
+    assert sample["images"].shape[0] == 2 * len(CAMERAS), "Images should still load"
+    print("✓ test_pointmap_is_optional passed")
 
 
 @with_mock_dataset
@@ -322,6 +374,8 @@ def run_all_tests():
         test_cam2rig_follows_camera_order,
         test_intrinsics_scaled_to_image_size,
         test_world_from_rig_is_per_frame,
+        test_pointmap_is_loaded_per_view,
+        test_pointmap_is_optional,
         test_dataset_missing_poses,
         test_dataset_missing_calibration,
         test_images_are_decoded_pixels,

--- a/utils/raymap.py
+++ b/utils/raymap.py
@@ -1,4 +1,4 @@
-"""Raymap ground truth from camera calibration and rig poses.
+"""Geometric ground truth from camera calibration and rig poses.
 
 The model's raymap heads predict one ray per patch token, so the targets are
 built on the same patch grid: `pose_raymap` as unit directions relative to the
@@ -42,6 +42,44 @@ def camera_ray_directions(intrinsics, image_size, patch_size):
     return torch.nn.functional.normalize(directions, dim=-1)
 
 
+def reference_from_camera(cam2rig, world_from_rig):
+    """Each view's camera pose relative to view 0. (B, V, 4, 4)"""
+    world_from_camera = world_from_rig @ cam2rig
+    return torch.linalg.inv(world_from_camera[:, :1]) @ world_from_camera
+
+
+def build_pointmap_target(pointmap, cam2rig, world_from_rig, patch_size, image_size):
+    """Sparse per-camera lidar pointmaps -> pointmap target in view 0's frame.
+
+    Args:
+        pointmap:       (B, V, G, G, 3) points in each view's own camera frame,
+                        NaN where no lidar return landed
+        cam2rig:        (B, V, 4, 4)
+        world_from_rig: (B, V, 4, 4)
+        patch_size:     model patch size
+        image_size:     (H, W)
+    Returns:
+        (points, confidence) of shape (B, V, P, 3) and (B, V, P), confidence being
+        the fraction of cells in each patch that carried a return.
+    """
+    B, V, G, _, _ = pointmap.shape
+    grid = image_size[0] // patch_size
+
+    # pool the export grid down to the patch grid, ignoring empty cells
+    blocks = pointmap.reshape(B, V, grid, G // grid, grid, G // grid, 3)
+    blocks = blocks.permute(0, 1, 2, 4, 3, 5, 6).reshape(B, V, grid * grid, -1, 3)
+    valid = ~torch.isnan(blocks[..., 0])
+    confidence = valid.float().mean(-1)
+    points = torch.nan_to_num(blocks).sum(-2) / valid.sum(-1).clamp(min=1).unsqueeze(-1)
+
+    # each view's points sit in its own camera frame; the prediction is in view 0's
+    transform = reference_from_camera(cam2rig, world_from_rig)
+    points = torch.einsum("bvij,bvpj->bvpi", transform[..., :3, :3], points)
+    points = points + transform[..., :3, 3].unsqueeze(2)
+
+    return points * (confidence > 0).unsqueeze(-1), confidence
+
+
 def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_size):
     """Targets for the rig and pose raymap heads.
 
@@ -64,12 +102,8 @@ def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_
     rig_raymap = torch.cat([rig_origins, rig_directions], dim=-1)
 
     # --- pose frame: relative to view 0, so rig motion shows up in the target ---
-    world_from_camera = world_from_rig @ cam2rig
-    reference_from_world = torch.linalg.inv(world_from_camera[:, :1])
-    reference_from_camera = reference_from_world @ world_from_camera
-    pose_directions = torch.einsum(
-        "bvij,bvpj->bvpi", reference_from_camera[..., :3, :3], directions
-    )
+    transform = reference_from_camera(cam2rig, world_from_rig)
+    pose_directions = torch.einsum("bvij,bvpj->bvpi", transform[..., :3, :3], directions)
 
     return {
         "rig_raymap": rig_raymap,


### PR DESCRIPTION
## Summary

`cam2rig-ptcloud` turned on two of the three loss terms — `pose_raymap` and
`rig_raymap`, both built from calibration and rig poses. The third, `pointmap`,
had no ground truth on Waymo and was skipped, so the model was learning camera
geometry but nothing about depth.

This PR exports the `lidar` component, projects the TOP lidar into every camera,
and turns the result into sparse per-patch pointmap targets. All three terms are
now active.

It also corrects a timing error the lidar work exposed in the existing pose
export

## Changes

### New: `ops/parquet2pointmap.py`

Converts range images to 3D and projects them into each camera:

```bash
python ops/parquet2pointmap.py --src data/waymo_mini --dst /data/waymo_mini
python ops/parquet2pointmap.py --src data/waymo_mini --verify
```

| Flag | Default | Meaning |
| --- | --- | --- |
| `--src` | `data/waymo_mini` | Root of the downloaded parquet dataset |
| `--dst` | `/data/waymo_mini` | Where to write the pointmaps |
| `--splits` | `train validation` | Splits to convert |
| `--grid` | `64` | Cells per side, pooled to the patch grid at load |
| `--verify` | off | Reproject against Waymo's own projections instead of writing |

The pipeline is: range image → polar → cartesian in the sensor frame → vehicle at
each pixel's own time (the TOP lidar spins across the frame) → world → each
camera's own frame. Which pixel a return lands on comes from Waymo's
`lidar_camera_projection` component rather than our own projection, so only the
3D reconstruction is ours.

Output layout:

```
<dst>/<split>/<segment>/pointmap/<CAMERA>.npy      # (n_frames, 64, 64, 3) float16
<dst>/<split>/<segment>/pointmap/timestamps.json
```

Points are stored in **each camera's own frame**, `NaN` where no return landed.
Per-camera is the only frame that is self-consistent: the five cameras trigger at
different instants and the lidar sweeps across the frame, so no single shared
frame puts every point on its own camera's ray. About 24 MB per segment, 240 MB
for the 10-segment mini set, against 3.3 GB of JPEGs.

The export is **optional**. A tree without it still trains on raymap supervision
alone, unlike `calibration.json` and `poses.json` which are required.

### `--verify` caught a real bug

The first implementation used the per-frame `vehicle_pose` for every camera.
Reprojection error against Waymo's own projections:

| Segment | FRONT | SIDE_LEFT | SIDE_RIGHT |
| --- | --- | --- | --- |
| `10017090...6380` | 2.90 px | 36.16 px | 31.98 px |
| `10050810...5313` | 6.17 px | 35.12 px | **131.17 px** |
| `10023947...1120` | 1.62 px | 2.01 px | 1.99 px |

Front cameras were fine, side cameras were not, and only in segments where the
rig was moving — the signature of a timing error, not bad geometry. The fix is
`[CameraImageComponent].pose.transform`, the vehicle pose at each camera's own
trigger instant. After it, medians land around 2 px, with the worst segment at
57 px on SIDE_RIGHT.

### Breaking change

`poses.json` is now keyed `{timestamp: {camera: 4x4}}` instead of
`{timestamp: 4x4}`, holding each camera's capture-time pose. The `vehicle_pose`
component is no longer read at all.

**Existing exports must be regenerated** — re-run `ops/parquet2jpeg.py`.
`WaymoDataset` raises with a message pointing at it.

This improves the pose raymap targets from `cam2rig-ptcloud` as a side effect,
for the same reason it fixes the pointmaps. `world_from_rig` was already shaped
`(V, 4, 4)`, so `build_raymap_targets` needed no change at all.

### `utils/raymap.py`

- `reference_from_camera` — factored out of `build_raymap_targets`, now shared
  with the pointmap path so both express targets in view 0's frame identically.
- `build_pointmap_target` — pools the 64-grid down to the model's patch grid
  ignoring `NaN` cells, converts coverage into `pointmap_conf`, and moves each
  view's points from its own camera frame into view 0's.

`MultiTaskLoss` already supported `pointmap_conf` as a per-point weight; nothing
had ever produced it. Empty patches now contribute zero instead of dragging
targets toward the origin.

### `datasets/waymo.py`

Pointmaps are memory-mapped per segment (`mmap_mode="r"`) and sliced per sample,
so segment size does not bound memory. Timestamps without a pointmap row are
dropped from the index. Missing export returns an empty tensor rather than
raising.

### `scripts/train.py`

- `compute_loss` builds pointmap targets when the batch carries them, falling
  back to CO3D's dense pointcloud path when it does not.
- Loss weights now come from config (`loss.w_point` / `w_pose` / `w_rig`).

### Configs, Makefile, docs

`loss:` block added to both training configs. `make download-waymo-mini` and
`download-waymo-full` chain the pointmap export. `docs/DATA_PREP.md` gains the
export step, the flag table, and the accuracy caveat.

## Testing

```bash
python tests/test_raymap.py    # 11 passed
python tests/test_waymo.py     # 19 passed
```

New in `test_raymap.py`: pooling to the patch grid, confidence tracking coverage,
the camera → reference frame move, and the end-to-end invariant that a target
point lies on the ray of its own patch. New in `test_waymo.py`: pointmaps load
one-per-view preserving `NaN`, and are optional.

Verified on the real mini set — target points sit on their own patches' rays
across all five cameras and both frames of a window:

```
view 0..4  cos(point - centre, ray)   0.99999  0.99999  0.99994  0.99998  0.99986
patch coverage 62-92%,  depth median 7.9 m
```

One epoch on one segment trains with all three terms: train 25.1, val 90.9.

## Known limitations

1. **TOP lidar only.** It is the 64-beam 360° sensor covering every camera out to
   ~75 m. The four side lidars are 20 m near-field and use a different
   (min/max) beam inclination convention. 
2. **Rolling shutter is not modelled.** The ~2 px residual is per-row camera
   readout, which needs the `velocity` and `rolling_shutter_params` fields.
   At 128×128 training resolution even the worst observed segment stays under
   half a patch, so the targets are quantised more coarsely than the error.
3. **The loss terms are badly scaled.** Measured on a real batch, `pointmap` is
   24.6 against `pose_raymap` 1.01 and `rig_raymap` 1.00 — metric MSE in metres
   against two cosine terms bounded by 2. Weights default to 1.0 and are left
   for tuning; `w_point: 0.05` brings the total to 3.24.
4. **`rig_raymap` is scale-blind.** `MultiTaskLoss` scores it by cosine over the
   concatenated `(origin, direction)` 6-vector, so absolute rig translation is
   unsupervised. Splitting it into direction and `camera_center_rig` terms would
   fix it; pre-existing, not touched here.
