### PR TITLE
Give Waymo training a real supervision signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ setup-train:
 download-waymo-full:
 	sh ops/get_waymo_data_full.sh
 	python ops/parquet2jpeg.py --src /data/waymo --dst /data/waymo
+	python ops/parquet2pointmap.py --src /data/waymo --dst /data/waymo
 
 download-waymo-mini:
 	sh ops/get_waymo_data_mini.sh
 	python ops/parquet2jpeg.py --src /data/waymo_mini --dst /data/waymo_mini
+	python ops/parquet2pointmap.py --src /data/waymo_mini --dst /data/waymo_mini
 
 download-wayve101:
 	mkdir -p data/wayve_scenes_101

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -10,6 +10,7 @@ num_workers: 4
 epochs: 50
 n_frames: 24  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
+patch_size: 8  # must match the model; also sets the raymap target resolution
 
 # Optimizer configuration
 optimizer:

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -12,6 +12,13 @@ n_frames: 24  # consecutive timestamps per sample; views = n_frames * num_camera
 image_size: [128, 128]
 patch_size: 8  # must match the model; also sets the raymap target resolution
 
+# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
+# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+loss:
+  w_point: 1.0
+  w_pose: 1.0
+  w_rig: 1.0
+
 # Optimizer configuration
 optimizer:
   lr: 0.0001

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -10,6 +10,7 @@ num_workers: 4
 epochs: 1 #50
 n_frames: 2  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
+patch_size: 8  # must match the model; also sets the raymap target resolution
 
 # Optimizer configuration
 optimizer:

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -12,6 +12,13 @@ n_frames: 2  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
 patch_size: 8  # must match the model; also sets the raymap target resolution
 
+# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
+# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+loss:
+  w_point: 1.0
+  w_pose: 1.0
+  w_rig: 1.0
+
 # Optimizer configuration
 optimizer:
   lr: 0.0001

--- a/datasets/co3d.py
+++ b/datasets/co3d.py
@@ -119,8 +119,8 @@ class Co3DDataset(Dataset):
                 if f in frame_annots:
                     cam2rigs.append(torch.tensor(frame_annots[f]['cam2rig'], dtype=torch.float32))
                 else:
-                    cam2rigs.append(torch.eye(3))
-            metadata['cam2rig'] = torch.stack(cam2rigs)
+                    cam2rigs.append(torch.eye(4))
+            metadata['cam2rig'] = torch.stack(cam2rigs)  # (V, 4, 4)
         return metadata
     
     def _maybe_drop_metadata(self, metadata):
@@ -131,7 +131,7 @@ class Co3DDataset(Dataset):
                     # metadata[key] = None
                     # Replace with placeholder
                     if key == 'cam2rig':
-                        metadata[key] = torch.eye(3).unsqueeze(0).repeat(self.n_frames, 1, 1)
+                        metadata[key] = torch.eye(4).unsqueeze(0).repeat(self.n_frames, 1, 1)
                     elif key == 'camera_id':
                         metadata[key] = torch.full((self.n_frames,), -1, dtype=torch.long)
                     elif key == 'timestamp':

--- a/datasets/transform.py
+++ b/datasets/transform.py
@@ -1,9 +1,11 @@
 from torchvision import transforms
 
 def get_train_transforms(image_size=(224, 224)):
+    # No geometric augmentation here on purpose: pointmap and raymap targets are
+    # built from calibration, so a flip or crop that the targets don't see makes
+    # the supervision wrong rather than noisy. Photometric augmentation is safe.
     return transforms.Compose([
         transforms.Resize(image_size),
-        transforms.RandomHorizontalFlip(),
         transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406],

--- a/datasets/waymo.py
+++ b/datasets/waymo.py
@@ -18,6 +18,7 @@ class WaymoDataset(Dataset):
     Expected layout:
         root_dir/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
         root_dir/<split>/<segment>/calibration.json
+        root_dir/<split>/<segment>/poses.json
 
     One sample is a rig capture window: `n_frames` consecutive timestamps of one
     segment, each contributing one image per camera. Views per sample is
@@ -67,13 +68,23 @@ class WaymoDataset(Dataset):
 
         # index of (segment_dir, [timestamps]) sliding windows
         self.samples: List[Tuple[Path, List[str]]] = []
-        # segment name -> (n_cameras, 4, 4), static for the whole segment
-        self.cam2rig: Dict[str, torch.Tensor] = {}
+        # segment name -> per-camera geometry, static for the whole segment
+        self.cam2rig: Dict[str, torch.Tensor] = {}  # (n_cameras, 4, 4)
+        self.intrinsics: Dict[str, torch.Tensor] = {}  # (n_cameras, 4)
+        # segment name -> {timestamp: world_from_rig (4, 4)}
+        self.poses: Dict[str, Dict[str, torch.Tensor]] = {}
         for segment in segments:
             timestamps = self._shared_timestamps(segment)
             if not timestamps:
+                continue  # incomplete rig
+            poses = self._load_poses(segment)
+            timestamps = [t for t in timestamps if t in poses]
+            if not timestamps:
                 continue
-            self.cam2rig[segment.name] = self._load_cam2rig(segment)
+            self.cam2rig[segment.name], self.intrinsics[segment.name] = (
+                self._load_calibration(segment)
+            )
+            self.poses[segment.name] = poses
             for i in range(len(timestamps) - n_frames + 1):
                 self.samples.append((segment, timestamps[i : i + n_frames]))
 
@@ -108,23 +119,37 @@ class WaymoDataset(Dataset):
 
         images = torch.stack(images)  # (n_frames * n_cameras, 3, H, W)
 
-        # the rig is rigid, so one block of per-camera extrinsics tiles over frames,
+        # the rig is rigid, so one block of per-camera geometry tiles over frames,
         # matching the (timestamp, camera) order the images were stacked in
-        cam2rig = self.cam2rig[segment.name].repeat(len(timestamps), 1, 1)
+        n_frames = len(timestamps)
+        cam2rig = self.cam2rig[segment.name].repeat(n_frames, 1, 1)
+        intrinsics = self.intrinsics[segment.name].repeat(n_frames, 1)
+
+        # the rig moves, so world_from_rig is per timestamp, held across the cameras
+        poses = self.poses[segment.name]
+        world_from_rig = torch.stack(
+            [poses[timestamp] for timestamp in timestamps]
+        ).repeat_interleave(len(self.cameras), dim=0)
 
         return {
             "images": images,
             "metadata": {"cam2rig": cam2rig},  # (n_frames * n_cameras, 4, 4)
+            "intrinsics": intrinsics,  # (n_frames * n_cameras, 4)
+            "world_from_rig": world_from_rig,  # (n_frames * n_cameras, 4, 4)
             "pointcloud": torch.empty(0, 3),
             "segment_id": segment.name,
             "timestamps": [int(t) for t in timestamps],
         }
 
-    def _load_cam2rig(self, segment: Path) -> torch.Tensor:
-        """Per-camera vehicle_from_camera SE(3), in self.cameras order.
+    def _load_calibration(self, segment: Path) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Per-camera (cam2rig, intrinsics) in self.cameras order.
 
         Waymo's rig frame is the vehicle frame, so the calibration component's
         extrinsic.transform is cam2rig directly - no composition needed.
+
+        Intrinsics are stored at native resolution and scaled here to self.image_size,
+        which assumes the transform pipeline is a plain resize to that size. A
+        transform that crops or pads would need its own adjustment.
         """
         calibration_file = segment / "calibration.json"
         if not calibration_file.exists():
@@ -138,10 +163,38 @@ class WaymoDataset(Dataset):
         if missing:
             raise ValueError(f"{calibration_file} has no calibration for {missing}")
 
-        return torch.tensor(
-            [calibration[camera]["cam2rig"] for camera in self.cameras],
-            dtype=torch.float32,
-        ).reshape(len(self.cameras), 4, 4)
+        height, width = self.image_size
+        cam2rig, intrinsics = [], []
+        for camera in self.cameras:
+            entry = calibration[camera]
+            scale_u = width / entry["width"]
+            scale_v = height / entry["height"]
+            cam2rig.append(entry["cam2rig"])
+            intrinsics.append([
+                entry["f_u"] * scale_u,
+                entry["f_v"] * scale_v,
+                entry["c_u"] * scale_u,
+                entry["c_v"] * scale_v,
+            ])
+
+        return (
+            torch.tensor(cam2rig, dtype=torch.float32).reshape(len(self.cameras), 4, 4),
+            torch.tensor(intrinsics, dtype=torch.float32),
+        )
+
+    def _load_poses(self, segment: Path) -> Dict[str, torch.Tensor]:
+        """world_from_rig SE(3) per frame timestamp."""
+        poses_file = segment / "poses.json"
+        if not poses_file.exists():
+            raise ValueError(
+                f"Poses not found: {poses_file}\n"
+                f"Re-run `python ops/parquet2jpeg.py` to export it alongside the images."
+            )
+
+        return {
+            timestamp: torch.tensor(transform, dtype=torch.float32).reshape(4, 4)
+            for timestamp, transform in json.loads(poses_file.read_text()).items()
+        }
 
     def get_sequence_ids(self) -> List[str]:
         """Returns the segment IDs actually indexed, in order, without duplicates."""

--- a/datasets/waymo.py
+++ b/datasets/waymo.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
+import numpy
 import torch
 from PIL import Image
 from torch.utils.data import Dataset
@@ -71,14 +72,22 @@ class WaymoDataset(Dataset):
         # segment name -> per-camera geometry, static for the whole segment
         self.cam2rig: Dict[str, torch.Tensor] = {}  # (n_cameras, 4, 4)
         self.intrinsics: Dict[str, torch.Tensor] = {}  # (n_cameras, 4)
-        # segment name -> {timestamp: world_from_rig (4, 4)}
-        self.poses: Dict[str, Dict[str, torch.Tensor]] = {}
+        # segment name -> {timestamp: {camera: world_from_rig (4, 4)}}
+        self.poses: Dict[str, Dict[str, Dict[str, torch.Tensor]]] = {}
+        # segment name -> ({timestamp: row}, {camera: memmapped (n_frames, G, G, 3)})
+        self.pointmaps: Dict[str, Tuple[Dict[str, int], Dict[str, numpy.ndarray]]] = {}
         for segment in segments:
             timestamps = self._shared_timestamps(segment)
             if not timestamps:
                 continue  # incomplete rig
             poses = self._load_poses(segment)
             timestamps = [t for t in timestamps if t in poses]
+
+            pointmaps = self._load_pointmaps(segment)
+            if pointmaps is not None:
+                self.pointmaps[segment.name] = pointmaps
+                timestamps = [t for t in timestamps if t in pointmaps[0]]
+
             if not timestamps:
                 continue
             self.cam2rig[segment.name], self.intrinsics[segment.name] = (
@@ -125,17 +134,20 @@ class WaymoDataset(Dataset):
         cam2rig = self.cam2rig[segment.name].repeat(n_frames, 1, 1)
         intrinsics = self.intrinsics[segment.name].repeat(n_frames, 1)
 
-        # the rig moves, so world_from_rig is per timestamp, held across the cameras
+        # the rig moves and each camera fires at its own instant, so this is per view
         poses = self.poses[segment.name]
-        world_from_rig = torch.stack(
-            [poses[timestamp] for timestamp in timestamps]
-        ).repeat_interleave(len(self.cameras), dim=0)
+        world_from_rig = torch.stack([
+            poses[timestamp][camera]
+            for timestamp in timestamps
+            for camera in self.cameras
+        ])
 
         return {
             "images": images,
             "metadata": {"cam2rig": cam2rig},  # (n_frames * n_cameras, 4, 4)
             "intrinsics": intrinsics,  # (n_frames * n_cameras, 4)
             "world_from_rig": world_from_rig,  # (n_frames * n_cameras, 4, 4)
+            "pointmap": self._pointmap(segment, timestamps),
             "pointcloud": torch.empty(0, 3),
             "segment_id": segment.name,
             "timestamps": [int(t) for t in timestamps],
@@ -182,8 +194,8 @@ class WaymoDataset(Dataset):
             torch.tensor(intrinsics, dtype=torch.float32),
         )
 
-    def _load_poses(self, segment: Path) -> Dict[str, torch.Tensor]:
-        """world_from_rig SE(3) per frame timestamp."""
+    def _load_poses(self, segment: Path) -> Dict[str, Dict[str, torch.Tensor]]:
+        """world_from_rig SE(3) per frame timestamp, per camera capture instant."""
         poses_file = segment / "poses.json"
         if not poses_file.exists():
             raise ValueError(
@@ -191,10 +203,52 @@ class WaymoDataset(Dataset):
                 f"Re-run `python ops/parquet2jpeg.py` to export it alongside the images."
             )
 
+        poses = json.loads(poses_file.read_text())
         return {
-            timestamp: torch.tensor(transform, dtype=torch.float32).reshape(4, 4)
-            for timestamp, transform in json.loads(poses_file.read_text()).items()
+            timestamp: {
+                camera: torch.tensor(transform, dtype=torch.float32).reshape(4, 4)
+                for camera, transform in cameras.items()
+            }
+            for timestamp, cameras in poses.items()
+            if all(camera in cameras for camera in self.cameras)
         }
+
+    def _load_pointmaps(self, segment: Path):
+        """({timestamp: row}, {camera: memmapped array}), or None if not exported.
+
+        Optional on purpose: without it training still runs on raymap supervision
+        alone, which is what every tree exported before ops/parquet2pointmap.py has.
+        """
+        directory = segment / "pointmap"
+        if not directory.is_dir():
+            return None
+
+        timestamps = json.loads((directory / "timestamps.json").read_text())
+        arrays = {
+            camera: numpy.load(directory / f"{camera}.npy", mmap_mode="r")
+            for camera in self.cameras
+        }
+        return {timestamp: row for row, timestamp in enumerate(timestamps)}, arrays
+
+    def _pointmap(self, segment: Path, timestamps: List[str]) -> torch.Tensor:
+        """Sparse lidar pointmap per view, in that view's own camera frame.
+
+        (n_frames * n_cameras, grid, grid, 3), NaN where no lidar return landed.
+        Empty (0, 0, 0, 3) when the segment has no pointmap export, so training
+        falls back to raymap-only supervision instead of failing.
+        """
+        grids = self.pointmaps.get(segment.name)
+        if grids is None:
+            return torch.empty(0, 0, 0, 3)
+
+        rows, arrays = grids
+        return torch.from_numpy(
+            numpy.stack([
+                arrays[camera][rows[timestamp]]
+                for timestamp in timestamps
+                for camera in self.cameras
+            ])
+        ).float()
 
     def get_sequence_ids(self) -> List[str]:
         """Returns the segment IDs actually indexed, in order, without duplicates."""

--- a/datasets/waymo.py
+++ b/datasets/waymo.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -16,6 +17,7 @@ class WaymoDataset(Dataset):
 
     Expected layout:
         root_dir/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
+        root_dir/<split>/<segment>/calibration.json
 
     One sample is a rig capture window: `n_frames` consecutive timestamps of one
     segment, each contributing one image per camera. Views per sample is
@@ -65,8 +67,13 @@ class WaymoDataset(Dataset):
 
         # index of (segment_dir, [timestamps]) sliding windows
         self.samples: List[Tuple[Path, List[str]]] = []
+        # segment name -> (n_cameras, 4, 4), static for the whole segment
+        self.cam2rig: Dict[str, torch.Tensor] = {}
         for segment in segments:
             timestamps = self._shared_timestamps(segment)
+            if not timestamps:
+                continue
+            self.cam2rig[segment.name] = self._load_cam2rig(segment)
             for i in range(len(timestamps) - n_frames + 1):
                 self.samples.append((segment, timestamps[i : i + n_frames]))
 
@@ -101,19 +108,40 @@ class WaymoDataset(Dataset):
 
         images = torch.stack(images)  # (n_frames * n_cameras, 3, H, W)
 
+        # the rig is rigid, so one block of per-camera extrinsics tiles over frames,
+        # matching the (timestamp, camera) order the images were stacked in
+        cam2rig = self.cam2rig[segment.name].repeat(len(timestamps), 1, 1)
+
         return {
             "images": images,
-            "metadata": {"cam2rig": self._cam2rig(images.shape[0])},
+            "metadata": {"cam2rig": cam2rig},  # (n_frames * n_cameras, 4, 4)
             "pointcloud": torch.empty(0, 3),
             "segment_id": segment.name,
             "timestamps": [int(t) for t in timestamps],
         }
 
-    def _cam2rig(self, n_views: int) -> torch.Tensor:
-        # ponytail: identity extrinsics - the JPEG export carries no calibration.
-        # Real values live in the camera_calibration parquet component; export
-        # them alongside the images and read them here when rig geometry matters.
-        return torch.eye(3).repeat(n_views, 1)  # (n_views * 3, 3)
+    def _load_cam2rig(self, segment: Path) -> torch.Tensor:
+        """Per-camera vehicle_from_camera SE(3), in self.cameras order.
+
+        Waymo's rig frame is the vehicle frame, so the calibration component's
+        extrinsic.transform is cam2rig directly - no composition needed.
+        """
+        calibration_file = segment / "calibration.json"
+        if not calibration_file.exists():
+            raise ValueError(
+                f"Calibration not found: {calibration_file}\n"
+                f"Re-run `python ops/parquet2jpeg.py` to export it alongside the images."
+            )
+
+        calibration = json.loads(calibration_file.read_text())
+        missing = [camera for camera in self.cameras if camera not in calibration]
+        if missing:
+            raise ValueError(f"{calibration_file} has no calibration for {missing}")
+
+        return torch.tensor(
+            [calibration[camera]["cam2rig"] for camera in self.cameras],
+            dtype=torch.float32,
+        ).reshape(len(self.cameras), 4, 4)
 
     def get_sequence_ids(self) -> List[str]:
         """Returns the segment IDs actually indexed, in order, without duplicates."""

--- a/docs/DATA_PREP.md
+++ b/docs/DATA_PREP.md
@@ -40,8 +40,10 @@ make download-waymo-mini
 Training reads images, not parquet. `ops/parquet2jpeg.py` pulls the
 `[CameraImageComponent].image` column out of the `camera_image` parquet files and
 writes the JPEG bytes straight to disk — no decode/re-encode, the payload is
-already JPEG. The `make` targets above run it for you; run it directly to
-re-export, or to use a different location:
+already JPEG. It also writes one `calibration.json` per segment from the
+`camera_calibration` component, which is where the rig extrinsics come from. The
+`make` targets above run it for you; run it directly to re-export, or to use a
+different location:
 
 ```bash
 python ops/parquet2jpeg.py --src data/waymo_mini --dst /data/waymo_mini
@@ -58,10 +60,18 @@ Output layout:
 
 ```
 <dst>/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
+<dst>/<split>/<segment>/calibration.json
 ```
 
 with `<CAMERA>` one of `FRONT`, `FRONT_LEFT`, `FRONT_RIGHT`, `SIDE_LEFT`, `SIDE_RIGHT`.
 Re-running overwrites existing files in place.
+
+`calibration.json` holds, per camera, the 4x4 `cam2rig` (Waymo's
+`extrinsic.transform`, a `vehicle_from_camera` — the rig frame *is* the vehicle
+frame) plus `f_u`/`f_v`/`c_u`/`c_v` and native `width`/`height`. Intrinsics are
+stored unscaled, so anything that resizes the images must scale them itself.
+`WaymoDataset` raises if this file is missing — a tree exported before calibration
+support needs a re-run.
 
 ### 5. Point the training config at it
 

--- a/docs/DATA_PREP.md
+++ b/docs/DATA_PREP.md
@@ -61,6 +61,7 @@ Output layout:
 ```
 <dst>/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
 <dst>/<split>/<segment>/calibration.json
+<dst>/<split>/<segment>/poses.json
 ```
 
 with `<CAMERA>` one of `FRONT`, `FRONT_LEFT`, `FRONT_RIGHT`, `SIDE_LEFT`, `SIDE_RIGHT`.
@@ -69,9 +70,19 @@ Re-running overwrites existing files in place.
 `calibration.json` holds, per camera, the 4x4 `cam2rig` (Waymo's
 `extrinsic.transform`, a `vehicle_from_camera` — the rig frame *is* the vehicle
 frame) plus `f_u`/`f_v`/`c_u`/`c_v` and native `width`/`height`. Intrinsics are
-stored unscaled, so anything that resizes the images must scale them itself.
-`WaymoDataset` raises if this file is missing — a tree exported before calibration
-support needs a re-run.
+stored unscaled; `WaymoDataset` rescales them to `image_size` on load.
+
+`poses.json` maps each frame timestamp to a 4x4 `world_from_vehicle`. Without it
+every frame's rays would be identical and pose supervision would be degenerate,
+so the loader skips timestamps that have no pose.
+
+Both files are required: `WaymoDataset` raises if either is missing, and a tree
+exported before they existed needs a re-run.
+
+Together they are what supervises training — `utils/raymap.py` turns calibration
+plus poses into the `rig_raymap` and `pose_raymap` targets that `MultiTaskLoss`
+scores. Pointmap supervision still needs the `lidar` component and is skipped for
+now, so only two of the three loss terms are active on Waymo.
 
 ### 5. Point the training config at it
 

--- a/docs/DATA_PREP.md
+++ b/docs/DATA_PREP.md
@@ -62,6 +62,8 @@ Output layout:
 <dst>/<split>/<segment>/<CAMERA>/<frame_timestamp_micros>.jpeg
 <dst>/<split>/<segment>/calibration.json
 <dst>/<split>/<segment>/poses.json
+<dst>/<split>/<segment>/pointmap/<CAMERA>.npy      # from parquet2pointmap.py
+<dst>/<split>/<segment>/pointmap/timestamps.json
 ```
 
 with `<CAMERA>` one of `FRONT`, `FRONT_LEFT`, `FRONT_RIGHT`, `SIDE_LEFT`, `SIDE_RIGHT`.
@@ -72,19 +74,53 @@ Re-running overwrites existing files in place.
 frame) plus `f_u`/`f_v`/`c_u`/`c_v` and native `width`/`height`. Intrinsics are
 stored unscaled; `WaymoDataset` rescales them to `image_size` on load.
 
-`poses.json` maps each frame timestamp to a 4x4 `world_from_vehicle`. Without it
-every frame's rays would be identical and pose supervision would be degenerate,
-so the loader skips timestamps that have no pose.
+`poses.json` maps each frame timestamp to a 4x4 `world_from_vehicle` **per camera**,
+taken at that camera's own trigger instant rather than once per frame. The five
+cameras do not fire together, so a single per-frame pose leaves points tens of
+pixels off their own camera's rays whenever the rig is moving.
 
 Both files are required: `WaymoDataset` raises if either is missing, and a tree
 exported before they existed needs a re-run.
 
 Together they are what supervises training — `utils/raymap.py` turns calibration
 plus poses into the `rig_raymap` and `pose_raymap` targets that `MultiTaskLoss`
-scores. Pointmap supervision still needs the `lidar` component and is skipped for
-now, so only two of the three loss terms are active on Waymo.
+scores.
 
-### 5. Point the training config at it
+### 5. The lidar pointmaps
+
+`ops/parquet2pointmap.py` adds the third loss term, projecting the TOP lidar into
+each camera to get sparse depth. The `make` targets run it; run it directly to
+re-export:
+
+```bash
+python ops/parquet2pointmap.py --src data/waymo_mini --dst /data/waymo_mini
+python ops/parquet2pointmap.py --src data/waymo_mini --verify
+```
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--src` | `data/waymo_mini` | Root of the downloaded parquet dataset |
+| `--dst` | `/data/waymo_mini` | Where to write the pointmaps |
+| `--splits` | `train validation` | Splits to convert |
+| `--grid` | `64` | Cells per side, pooled to the patch grid at load |
+| `--verify` | off | Reproject against Waymo's own projections instead of writing |
+
+Each `<CAMERA>.npy` is `(n_frames, grid, grid, 3)` float16 holding points in that
+camera's own frame, `NaN` where no return landed, about 24 MB per segment. The
+loader pools the grid down to the model's patch grid and turns coverage into
+`pointmap_conf`, so empty patches contribute nothing to the loss.
+
+Unlike the other two files this one is **optional** — without it training still
+runs on raymap supervision alone.
+
+`--verify` is the check on the range-image math: it reprojects the computed points
+through the camera intrinsics and compares against the `lidar_camera_projection`
+component. Expect a median around 2 px at native 1920x1280 resolution. The residual
+is per-row rolling shutter, which needs the `velocity` and `rolling_shutter_params`
+fields to model; at 128x128 training resolution even the worst observed segment
+stays under half a patch, so it is left uncorrected.
+
+### 6. Point the training config at it
 
 `waymo_path` in [`configs/train_waymo.yaml`](../configs/train_waymo.yaml) must match
 your `--dst`:

--- a/models/decoder_transformer.py
+++ b/models/decoder_transformer.py
@@ -75,7 +75,7 @@ class RigAwareTransformerDecoder(nn.Module):
 
         # --- Per-key projections ---
         self.key_projs = nn.ModuleDict({
-            "cam2rig": nn.Linear(3, embed_dim)  # 3 tokens, each 3D
+            "cam2rig": nn.Linear(16, embed_dim)  # one token per view, a flattened 4x4 SE(3)
         })
 
         # metadata projector: maps external metadata -> embed_dim tokens
@@ -112,7 +112,9 @@ class RigAwareTransformerDecoder(nn.Module):
             if value is None:
                 continue
             v = value.to(device)
-            if v.dim() == 2:
+            if v.dim() == 4:
+                v = v.flatten(2) # (B, V, 4, 4) -> (B, V, 16), one token per view
+            elif v.dim() == 2:
                 v = v.unsqueeze(1) # (B, D) -> (B, 1, D)
             elif v.dim() != 3:
                 raise ValueError(f"Unsupported metadata shape for key {key}: {v.shape}")

--- a/ops/parquet2jpeg.py
+++ b/ops/parquet2jpeg.py
@@ -1,9 +1,11 @@
-"""Extract Waymo camera_image parquet -> JPEG files.
+"""Extract Waymo camera_image parquet -> JPEG files, plus per-segment calibration.
 
 Layout: DST/<split>/<segment>/<camera>/<frame_timestamp_micros>.jpeg
+        DST/<split>/<segment>/calibration.json
 """
 
 import argparse
+import json
 from pathlib import Path
 
 import pyarrow.parquet as pq
@@ -19,6 +21,47 @@ COLS = [
     "key.frame_timestamp_micros",
     "[CameraImageComponent].image",
 ]
+
+CALIB = "[CameraCalibrationComponent]"
+CALIB_COLS = [
+    "key.camera_name",
+    f"{CALIB}.extrinsic.transform",
+    f"{CALIB}.intrinsic.f_u",
+    f"{CALIB}.intrinsic.f_v",
+    f"{CALIB}.intrinsic.c_u",
+    f"{CALIB}.intrinsic.c_v",
+    f"{CALIB}.width",
+    f"{CALIB}.height",
+]
+
+
+def convert_calibration(src, dst, split):
+    """Write one calibration.json per segment: 5 rows, static for the whole segment.
+
+    extrinsic.transform is a 4x4 vehicle_from_camera, i.e. cam2rig as-is (the rig
+    frame is the vehicle frame). Intrinsics are stored at native resolution; a
+    consumer that resizes must scale f/c by its own (out / width, out / height).
+    """
+    files = sorted((src / split / "camera_calibration").glob("*.parquet"))
+
+    for path in tqdm(files, desc=f"{split} calibration"):
+        rows = pq.read_table(path, columns=CALIB_COLS).to_pylist()
+        calibration = {
+            CAMERAS.get(row["key.camera_name"], f"CAMERA_{row['key.camera_name']}"): {
+                "cam2rig": row[f"{CALIB}.extrinsic.transform"],  # row-major 4x4
+                "f_u": row[f"{CALIB}.intrinsic.f_u"],
+                "f_v": row[f"{CALIB}.intrinsic.f_v"],
+                "c_u": row[f"{CALIB}.intrinsic.c_u"],
+                "c_v": row[f"{CALIB}.intrinsic.c_v"],
+                "width": row[f"{CALIB}.width"],
+                "height": row[f"{CALIB}.height"],
+            }
+            for row in rows
+        }
+
+        out_dir = dst / split / path.stem
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "calibration.json").write_text(json.dumps(calibration, indent=2))
 
 
 def convert_split(src, dst, split):
@@ -52,3 +95,4 @@ if __name__ == "__main__":
     args = parse_args()
     for split in args.splits:
         convert_split(args.src, args.dst, split)
+        convert_calibration(args.src, args.dst, split)

--- a/ops/parquet2jpeg.py
+++ b/ops/parquet2jpeg.py
@@ -1,7 +1,8 @@
-"""Extract Waymo camera_image parquet -> JPEG files, plus per-segment calibration.
+"""Extract Waymo camera_image parquet -> JPEG files, plus per-segment geometry.
 
 Layout: DST/<split>/<segment>/<camera>/<frame_timestamp_micros>.jpeg
         DST/<split>/<segment>/calibration.json
+        DST/<split>/<segment>/poses.json
 """
 
 import argparse
@@ -34,6 +35,11 @@ CALIB_COLS = [
     f"{CALIB}.height",
 ]
 
+POSE_COLS = [
+    "key.frame_timestamp_micros",
+    "[VehiclePoseComponent].world_from_vehicle.transform",
+]
+
 
 def convert_calibration(src, dst, split):
     """Write one calibration.json per segment: 5 rows, static for the whole segment.
@@ -62,6 +68,28 @@ def convert_calibration(src, dst, split):
         out_dir = dst / split / path.stem
         out_dir.mkdir(parents=True, exist_ok=True)
         (out_dir / "calibration.json").write_text(json.dumps(calibration, indent=2))
+
+
+def convert_poses(src, dst, split):
+    """Write one poses.json per segment: world_from_vehicle 4x4 per frame timestamp.
+
+    This is what makes rays from different frames comparable, so pose supervision
+    is not just the static rig repeated.
+    """
+    files = sorted((src / split / "vehicle_pose").glob("*.parquet"))
+
+    for path in tqdm(files, desc=f"{split} poses"):
+        rows = pq.read_table(path, columns=POSE_COLS).to_pylist()
+        poses = {
+            str(row["key.frame_timestamp_micros"]): row[
+                "[VehiclePoseComponent].world_from_vehicle.transform"
+            ]
+            for row in rows
+        }
+
+        out_dir = dst / split / path.stem
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "poses.json").write_text(json.dumps(poses))
 
 
 def convert_split(src, dst, split):
@@ -96,3 +124,4 @@ if __name__ == "__main__":
     for split in args.splits:
         convert_split(args.src, args.dst, split)
         convert_calibration(args.src, args.dst, split)
+        convert_poses(args.src, args.dst, split)

--- a/ops/parquet2jpeg.py
+++ b/ops/parquet2jpeg.py
@@ -37,7 +37,8 @@ CALIB_COLS = [
 
 POSE_COLS = [
     "key.frame_timestamp_micros",
-    "[VehiclePoseComponent].world_from_vehicle.transform",
+    "key.camera_name",
+    "[CameraImageComponent].pose.transform",
 ]
 
 
@@ -71,21 +72,27 @@ def convert_calibration(src, dst, split):
 
 
 def convert_poses(src, dst, split):
-    """Write one poses.json per segment: world_from_vehicle 4x4 per frame timestamp.
+    """Write one poses.json per segment: {timestamp: {camera: world_from_vehicle 4x4}}.
 
     This is what makes rays from different frames comparable, so pose supervision
     is not just the static rig repeated.
+
+    It is keyed per camera, not per frame, because the five cameras are triggered
+    at different instants within a frame - `vehicle_pose` holds one pose for the
+    whole frame, which leaves points tens of pixels off their own camera's rays
+    while the rig is moving. Reading the pose column skips the image bytes.
     """
-    files = sorted((src / split / "vehicle_pose").glob("*.parquet"))
+    files = sorted((src / split / "camera_image").glob("*.parquet"))
 
     for path in tqdm(files, desc=f"{split} poses"):
         rows = pq.read_table(path, columns=POSE_COLS).to_pylist()
-        poses = {
-            str(row["key.frame_timestamp_micros"]): row[
-                "[VehiclePoseComponent].world_from_vehicle.transform"
+        poses = {}
+        for row in rows:
+            timestamp = str(row["key.frame_timestamp_micros"])
+            camera = CAMERAS.get(row["key.camera_name"], f"CAMERA_{row['key.camera_name']}")
+            poses.setdefault(timestamp, {})[camera] = row[
+                "[CameraImageComponent].pose.transform"
             ]
-            for row in rows
-        }
 
         out_dir = dst / split / path.stem
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/ops/parquet2pointmap.py
+++ b/ops/parquet2pointmap.py
@@ -1,0 +1,269 @@
+"""Project Waymo TOP lidar into each camera -> per-frame sparse pointmaps.
+
+Layout: DST/<split>/<segment>/pointmap/<CAMERA>.npy   (n_frames, grid, grid, 3) float16
+        DST/<split>/<segment>/pointmap/timestamps.json
+
+Points are stored in each camera's *own* frame, with NaN where no lidar return
+landed in that cell. Per-camera is the only frame that is consistent: the five
+cameras are triggered at different times within a frame and the lidar spins
+across it, so a single shared vehicle frame leaves points off their own camera's
+rays by tens of pixels whenever the rig is moving. The loader re-expresses them
+relative to whichever view a training window starts at.
+
+`--verify` skips writing and instead reprojects the computed points back through
+the camera intrinsics, comparing against Waymo's own `lidar_camera_projection`.
+That is the check on the range-image math: if the geometry is wrong, the
+reprojection error blows up.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+from tqdm import tqdm
+
+SPLITS = ["train", "validation"]
+
+# waymo CameraName enum, matching ops/parquet2jpeg.py
+CAMERAS = {1: "FRONT", 2: "FRONT_LEFT", 3: "FRONT_RIGHT", 4: "SIDE_LEFT", 5: "SIDE_RIGHT"}
+
+# ponytail: TOP lidar only. It is the 64-beam 360-degree sensor covering every
+# camera out to ~75m; the four side lidars are 20m near-field and use a different
+# (min/max) inclination convention. Add them if close-range density matters.
+TOP = 1
+
+
+def rotation_matrix(roll, pitch, yaw):
+    """ZYX euler -> (..., 3, 3), matching waymo's transform_utils.get_rotation_matrix."""
+    cos_roll, sin_roll = np.cos(roll), np.sin(roll)
+    cos_pitch, sin_pitch = np.cos(pitch), np.sin(pitch)
+    cos_yaw, sin_yaw = np.cos(yaw), np.sin(yaw)
+    zeros, ones = np.zeros_like(cos_roll), np.ones_like(cos_roll)
+
+    shape = cos_roll.shape + (3, 3)
+    r_roll = np.stack([ones, zeros, zeros, zeros, cos_roll, -sin_roll,
+                       zeros, sin_roll, cos_roll], -1).reshape(shape)
+    r_pitch = np.stack([cos_pitch, zeros, sin_pitch, zeros, ones, zeros,
+                        -sin_pitch, zeros, cos_pitch], -1).reshape(shape)
+    r_yaw = np.stack([cos_yaw, -sin_yaw, zeros, sin_yaw, cos_yaw, zeros,
+                      zeros, zeros, ones], -1).reshape(shape)
+    return r_yaw @ r_pitch @ r_roll
+
+
+def transform(points, matrix):
+    """Apply a 4x4 SE(3) to (..., 3) points."""
+    return points @ matrix[:3, :3].T + matrix[:3, 3]
+
+
+def range_image_to_world(range_image, extrinsic, inclinations, pixel_pose):
+    """Range image -> cartesian points in the world frame.
+
+    The TOP lidar spins during the frame, so each pixel carries its own vehicle
+    pose. Points go sensor -> vehicle(pixel time) -> world, which is what removes
+    the rolling-shutter smear. World is the only frame shared by every sensor, so
+    the per-camera step downstream can pick up each camera's own capture time.
+    """
+    height, width, _ = range_image.shape
+
+    # azimuth runs backwards across the image and is offset by the sensor yaw
+    azimuth_correction = np.arctan2(extrinsic[1, 0], extrinsic[0, 0])
+    ratios = (np.arange(width, 0, -1) - 0.5) / width
+    azimuth = ((ratios * 2.0 - 1.0) * np.pi - azimuth_correction)[None, :]
+    inclination = inclinations[:, None]
+
+    ranges = range_image[..., 0]
+    points = np.stack([
+        np.cos(azimuth) * np.cos(inclination) * ranges,
+        np.sin(azimuth) * np.cos(inclination) * ranges,
+        np.sin(inclination) * ranges,
+    ], axis=-1)
+
+    points = transform(points, extrinsic)
+
+    pixel_rotation = rotation_matrix(pixel_pose[..., 0], pixel_pose[..., 1], pixel_pose[..., 2])
+    world = np.einsum("hwij,hwj->hwi", pixel_rotation, points) + pixel_pose[..., 3:]
+
+    return world, ranges
+
+
+def bin_to_grid(points, ranges, pixels, size, grid):
+    """Scatter projected points into a (grid, grid, 3) cell map, nearest return wins."""
+    width, height = size
+    cells = np.stack([
+        np.clip(pixels[:, 1] / height * grid, 0, grid - 1),
+        np.clip(pixels[:, 0] / width * grid, 0, grid - 1),
+    ], -1).astype(np.int32)
+
+    # writing far points first leaves the nearest surface in each cell
+    order = np.argsort(-ranges)
+    flat = np.full((grid * grid, 3), np.nan, dtype=np.float32)
+    flat[cells[order, 0] * grid + cells[order, 1]] = points[order]
+    return flat.reshape(grid, grid, 3)
+
+
+def camera_calibration(src, split, segment):
+    """{camera_name: (cam2rig, intrinsics, (width, height))}"""
+    table = pq.read_table(f"{src}/{split}/camera_calibration/{segment}.parquet").to_pylist()
+    prefix = "[CameraCalibrationComponent]"
+    return {
+        row["key.camera_name"]: (
+            np.array(row[f"{prefix}.extrinsic.transform"]).reshape(4, 4),
+            np.array([row[f"{prefix}.intrinsic.{k}"] for k in ("f_u", "f_v", "c_u", "c_v")]),
+            (row[f"{prefix}.width"], row[f"{prefix}.height"]),
+        )
+        for row in table
+    }
+
+
+def project(camera_points, intrinsics):
+    """Camera-frame points -> pixels, Waymo camera model (x forward, y left, z up)."""
+    f_u, f_v, c_u, c_v = intrinsics
+    u = f_u * (-camera_points[:, 1] / camera_points[:, 0]) + c_u
+    v = f_v * (-camera_points[:, 2] / camera_points[:, 0]) + c_v
+    return np.stack([u, v], -1)
+
+
+def read_camera_poses(src, split, segment):
+    """{(timestamp, camera_name): world_from_vehicle at that camera's capture time}.
+
+    Each camera is triggered at its own instant, so this is not the frame's
+    vehicle pose. Reading it skips the image column, so it stays cheap.
+    """
+    table = pq.read_table(
+        f"{src}/{split}/camera_image/{segment}.parquet",
+        columns=["key.frame_timestamp_micros", "key.camera_name",
+                 "[CameraImageComponent].pose.transform"],
+    ).to_pylist()
+    return {
+        (row["key.frame_timestamp_micros"], row["key.camera_name"]): np.array(
+            row["[CameraImageComponent].pose.transform"]
+        ).reshape(4, 4)
+        for row in table
+    }
+
+
+def read_top_frames(src, split, component, prefix, segment):
+    """{timestamp: range image array} for the TOP laser only."""
+    path = f"{src}/{split}/{component}/{segment}.parquet"
+    columns = ["key.frame_timestamp_micros", f"{prefix}.range_image_return1.values",
+               f"{prefix}.range_image_return1.shape"]
+    if component != "lidar_pose":
+        columns.insert(0, "key.laser_name")
+
+    parquet = pq.ParquetFile(path)
+    frames = {}
+    for group in range(parquet.metadata.num_row_groups):
+        table = parquet.read_row_group(group, columns=columns)
+        lasers = table.column("key.laser_name").to_pylist() if "key.laser_name" in columns else None
+        timestamps = table.column("key.frame_timestamp_micros").to_pylist()
+        values = table.column(f"{prefix}.range_image_return1.values")
+        shapes = table.column(f"{prefix}.range_image_return1.shape").to_pylist()
+
+        for i, timestamp in enumerate(timestamps):
+            if lasers is not None and lasers[i] != TOP:
+                continue
+            frames[timestamp] = np.asarray(values[i].values).reshape(shapes[i])
+    return frames
+
+
+def convert_segment(src, dst, split, segment, grid, verify):
+    calibration = pq.read_table(f"{src}/{split}/lidar_calibration/{segment}.parquet").to_pylist()
+    prefix = "[LiDARCalibrationComponent]"
+    top = next(row for row in calibration if row["key.laser_name"] == TOP)
+    extrinsic = np.array(top[f"{prefix}.extrinsic.transform"]).reshape(4, 4)
+    # range image row 0 is the topmost beam, so the stored inclinations are reversed
+    inclinations = np.array(top[f"{prefix}.beam_inclination.values"])[::-1]
+
+    poses = read_camera_poses(src, split, segment)
+    cameras = camera_calibration(src, split, segment)
+
+    lidar = read_top_frames(src, split, "lidar", "[LiDARComponent]", segment)
+    pixel_poses = read_top_frames(src, split, "lidar_pose", "[LiDARPoseComponent]", segment)
+    projections = read_top_frames(
+        src, split, "lidar_camera_projection", "[LiDARCameraProjectionComponent]", segment
+    )
+
+    timestamps = sorted(
+        t for t in lidar
+        if t in pixel_poses and t in projections
+        and all((t, camera_name) in poses for camera_name in CAMERAS)
+    )
+    pointmaps = {name: [] for name in CAMERAS.values()}
+    errors = {name: [] for name in CAMERAS.values()}
+
+    for timestamp in timestamps:
+        world, ranges = range_image_to_world(
+            lidar[timestamp], extrinsic, inclinations, pixel_poses[timestamp]
+        )
+        projection = projections[timestamp]
+        valid = ranges > 0
+
+        for camera_name, name in CAMERAS.items():
+            cam2rig, intrinsics, size = cameras[camera_name]
+            # each return may project into up to two cameras
+            hits = [
+                (projection[..., 0] == camera_name) & valid,
+                (projection[..., 3] == camera_name) & valid,
+            ]
+            selected = np.concatenate([world[hit] for hit in hits])
+            pixels = np.concatenate(
+                [projection[..., 1:3][hits[0]], projection[..., 4:6][hits[1]]]
+            )
+            depths = np.concatenate([ranges[hit] for hit in hits])
+
+            # world -> vehicle at this camera's capture time -> camera
+            world_from_camera = poses[(timestamp, camera_name)] @ cam2rig
+            selected = transform(selected, np.linalg.inv(world_from_camera))
+
+            if verify:
+                if len(selected):
+                    reprojected = project(selected, intrinsics)
+                    errors[name].append(np.linalg.norm(reprojected - pixels, axis=-1))
+                continue
+
+            pointmaps[name].append(bin_to_grid(selected, depths, pixels, size, grid))
+
+    if verify:
+        for name, batch in errors.items():
+            stacked = np.concatenate(batch)
+            print(f"  {name:12s} n={len(stacked):8d}  median={np.median(stacked):6.2f}px  "
+                  f"p99={np.percentile(stacked, 99):7.2f}px")
+        return
+
+    out_dir = dst / split / segment / "pointmap"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, frames in pointmaps.items():
+        np.save(out_dir / f"{name}.npy", np.stack(frames).astype(np.float16))
+    (out_dir / "timestamps.json").write_text(json.dumps([str(t) for t in timestamps]))
+
+
+def convert_split(src, dst, split, grid, verify):
+    segments = sorted(p.stem for p in (src / split / "lidar").glob("*.parquet"))
+    for segment in tqdm(segments, desc=f"{split} pointmaps"):
+        if verify:
+            print(f"\n{segment}")
+        convert_segment(str(src), dst, split, segment, grid, verify)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", type=Path, default=Path("data/waymo_mini"),
+                        help="Root of the downloaded parquet dataset (default: %(default)s)")
+    parser.add_argument("--dst", type=Path, default=Path("/data/waymo_mini"),
+                        help="Where to write the pointmaps (default: %(default)s)")
+    parser.add_argument("--splits", nargs="+", default=SPLITS,
+                        help="Splits to convert (default: %(default)s)")
+    parser.add_argument("--grid", type=int, default=64,
+                        help="Cells per side, pooled down to the patch grid at load "
+                             "(default: %(default)s)")
+    parser.add_argument("--verify", action="store_true",
+                        help="Reproject against waymo's own projections instead of writing")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    for split in args.splits:
+        convert_split(args.src, args.dst, split, args.grid, args.verify)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -20,7 +20,9 @@ from datasets.waymo import WaymoDataset
 from datasets.transform import get_train_transforms, get_val_transforms
 
 # --- Import model ---
-from models.rig3r import Rig3R  
+from models.rig3r import Rig3R
+from models.losses import MultiTaskLoss
+from utils.raymap import build_raymap_targets
 
 # --- Optional: logging ---
 import wandb
@@ -48,6 +50,7 @@ dataset_type = train_cfg.get("dataset_type", "co3d")
 # 2. Prepare datasets
 # -----------------------------
 img_size = tuple(train_cfg.get("image_size", [128, 128]))
+patch_size = train_cfg.get("patch_size", 8)
 
 if dataset_type == "co3d":
     co3d_path = Path.cwd().joinpath("data/co3d")
@@ -120,7 +123,7 @@ pretrain_ckpt_path = Path.cwd().joinpath("checkpoints/pretrained/DUSt3R_ViTLarge
 model = Rig3R(
     encoder_ckpt=pretrain_ckpt_path,
     img_size=img_size[0],
-    patch_size=8,
+    patch_size=patch_size,
     embed_dim=128,
     metadata_dim=128,
     num_decoder_layers=2,
@@ -143,47 +146,67 @@ scheduler = CosineAnnealingLR(optimizer,
                               eta_min=float(train_cfg["scheduler"]["eta_min"]))
 
 # -----------------------------
-# 5. Loss function (example)
+# 5. Loss function
 # -----------------------------
-def compute_loss(outputs, pointcloud_gt, img_size=128, patch_size=8):
+criterion = MultiTaskLoss()
+
+
+def downsample_pointmap(pointmap, img_size, patch_size):
+    """Dense (B, V, H*W, 3) prediction -> (B, V, P, 3) at patch resolution.
+
+    The pointmap head predicts at image resolution, but pointcloud ground truth
+    is sparse (P points, P = (img_size / patch_size)^2), so average-pool the
+    prediction down to meet it.
     """
-    Compute MSE loss between model output and ground truth pointcloud.
-
-    The model outputs dense predictions at image resolution (H*W points),
-    but ground truth may be sparse (P points where P = num_patches).
-    We downsample the model output to match the ground truth resolution.
-
-    Args:
-        outputs: dict with "pointmap" of shape (B, V, H*W, 3)
-        pointcloud_gt: ground truth of shape (B, V, P, 3) where P = (H/patch_size)^2
-        img_size: image height/width (assumes square)
-        patch_size: patch size used by the model
-    """
-    if pointcloud_gt.numel() == 0:
-        return torch.tensor(0.0, device=pointcloud_gt.device, requires_grad=True)
-
-    pointmap = outputs["pointmap"]  # (B, V, H*W, 3)
     B, V, _, C = pointmap.shape
     H = W = img_size
     patch_grid = img_size // patch_size  # e.g., 128 // 8 = 16
 
-    # Reshape to spatial format: (B, V, H*W, 3) -> (B*V, 3, H, W)
-    pointmap_spatial = pointmap.view(B * V, H, W, C).permute(0, 3, 1, 2)  # (B*V, 3, H, W)
+    # (B, V, H*W, 3) -> (B*V, 3, H, W)
+    spatial = pointmap.view(B * V, H, W, C).permute(0, 3, 1, 2)
+    pooled = nn.functional.avg_pool2d(spatial, kernel_size=patch_size, stride=patch_size)
 
-    # Downsample from (H, W) to (patch_grid, patch_grid) using average pooling
-    # This reduces 128x128 -> 16x16, matching the patch resolution
-    pointmap_downsampled = nn.functional.avg_pool2d(
-        pointmap_spatial,
-        kernel_size=patch_size,
-        stride=patch_size
-    )  # (B*V, 3, patch_grid, patch_grid)
+    # (B*V, 3, patch_grid, patch_grid) -> (B, V, P, 3)
+    return pooled.permute(0, 2, 3, 1).reshape(B, V, patch_grid * patch_grid, C)
 
-    # Reshape back to (B, V, P, 3) where P = patch_grid^2
-    P = patch_grid * patch_grid
-    pointmap_downsampled = pointmap_downsampled.permute(0, 2, 3, 1)  # (B*V, patch_grid, patch_grid, 3)
-    pointmap_downsampled = pointmap_downsampled.reshape(B, V, P, C)  # (B, V, P, 3)
 
-    return nn.MSELoss()(pointmap_downsampled, pointcloud_gt)
+def compute_loss(outputs, batch, device, img_size, patch_size):
+    """Score whatever supervision this batch actually carries.
+
+    Waymo currently supplies raymap targets (from calibration + rig poses) but no
+    pointcloud; CO3D supplies a pointcloud but no calibration. MultiTaskLoss skips
+    any term missing from either side, so each dataset trains on what it has.
+    """
+    preds = dict(outputs)
+    targets = {}
+
+    pointcloud = batch["pointcloud"].to(device)
+    if pointcloud.numel() > 0:
+        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
+        targets["pointmap"] = pointcloud
+
+    if "intrinsics" in batch:
+        targets.update(build_raymap_targets(
+            cam2rig=batch["metadata"]["cam2rig"].to(device),
+            intrinsics=batch["intrinsics"].to(device),
+            world_from_rig=batch["world_from_rig"].to(device),
+            image_size=img_size,
+            patch_size=patch_size,
+        ))
+
+    total, loss_dict = criterion(preds, targets)
+
+    # with no matching target MultiTaskLoss returns a plain 0.0 float and the
+    # optimizer becomes a no-op - the exact failure this pipeline shipped with.
+    # grad_fn is only expected under grad; validation runs inside no_grad.
+    connected = torch.is_tensor(total) and (
+        total.grad_fn is not None or not torch.is_grad_enabled()
+    )
+    assert connected, (
+        f"No supervision in this batch (targets: {sorted(targets)}). "
+        f"Export calibration/poses for raymaps, or a pointcloud for pointmaps."
+    )
+    return total, loss_dict
 
 
 # -----------------------------
@@ -192,14 +215,13 @@ def compute_loss(outputs, pointcloud_gt, img_size=128, patch_size=8):
 def unpack_batch(batch, device):
     """Move a collated sample dict onto the device. Same shape for co3d and waymo."""
     images = batch["images"].to(device)
-    pointcloud = batch["pointcloud"].to(device)
 
     metadata = batch["metadata"]
     for key, value in metadata.items():
         if value is not None:
             metadata[key] = value.to(device)
 
-    return images, metadata, pointcloud
+    return images, metadata
 
 
 # -----------------------------
@@ -226,19 +248,22 @@ for epoch in range(num_epochs):
     train_bar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Train]", leave=False)
     
     for batch_idx, batch in enumerate(train_bar):
-        images, metadata, pointcloud = unpack_batch(batch, device)
+        images, metadata = unpack_batch(batch, device)
 
         optimizer.zero_grad()
         with autocast(device_type=str(device)):
             outputs = model(images, metadata)
-        loss = compute_loss(outputs, pointcloud, img_size=img_size[0])
+        loss, loss_dict = compute_loss(outputs, batch, device, img_size, patch_size)
 
         loss.backward()
         optimizer.step()
 
         running_loss += loss.item()
         train_bar.set_postfix({"loss": f"{loss.item():.4f}"})
-        wandb.log({"train/batch_loss": loss.item()}, step=global_step)
+        wandb.log(
+            {f"train/batch_{name}": value.item() for name, value in loss_dict.items()},
+            step=global_step,
+        )
         global_step += 1
 
     scheduler.step()
@@ -253,11 +278,11 @@ for epoch in range(num_epochs):
     val_bar = tqdm(val_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Val]", leave=False)
     with torch.no_grad():
         for batch in val_bar:
-            images, metadata, pointcloud = unpack_batch(batch, device)
+            images, metadata = unpack_batch(batch, device)
 
             with autocast(device_type=str(device)):
                 outputs = model(images, metadata)
-            loss = compute_loss(outputs, pointcloud, img_size=img_size[0])
+            loss, _ = compute_loss(outputs, batch, device, img_size, patch_size)
 
             val_loss += loss.item()
             val_bar.set_postfix({"val_loss": f"{loss.item():.4f}"})

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,7 +22,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 # --- Import model ---
 from models.rig3r import Rig3R
 from models.losses import MultiTaskLoss
-from utils.raymap import build_raymap_targets
+from utils.raymap import build_pointmap_target, build_raymap_targets
 
 # --- Optional: logging ---
 import wandb
@@ -148,7 +148,14 @@ scheduler = CosineAnnealingLR(optimizer,
 # -----------------------------
 # 5. Loss function
 # -----------------------------
-criterion = MultiTaskLoss()
+# the pointmap term is a metric MSE in metres and runs an order of magnitude above
+# the two raymap terms, which are cosine-based and bounded by 2 - hence the weights
+loss_cfg = train_cfg.get("loss", {})
+criterion = MultiTaskLoss(
+    w_point=loss_cfg.get("w_point", 1.0),
+    w_pose=loss_cfg.get("w_pose", 1.0),
+    w_rig=loss_cfg.get("w_rig", 1.0),
+)
 
 
 def downsample_pointmap(pointmap, img_size, patch_size):
@@ -181,9 +188,20 @@ def compute_loss(outputs, batch, device, img_size, patch_size):
     targets = {}
 
     pointcloud = batch["pointcloud"].to(device)
+    pointmap = batch.get("pointmap", torch.empty(0)).to(device)
+
     if pointcloud.numel() > 0:
         preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
         targets["pointmap"] = pointcloud
+    elif pointmap.numel() > 0:
+        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
+        targets["pointmap"], targets["pointmap_conf"] = build_pointmap_target(
+            pointmap=pointmap,
+            cam2rig=batch["metadata"]["cam2rig"].to(device),
+            world_from_rig=batch["world_from_rig"].to(device),
+            patch_size=patch_size,
+            image_size=img_size,
+        )
 
     if "intrinsics" in batch:
         targets.update(build_raymap_targets(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -35,7 +35,7 @@ decoder = RigAwareTransformerDecoder(
 # meta = torch.randn(B, 2, 32)
 # dummy metadata: dictionary with cam2rig
 metadata = {
-    "cam2rig": torch.randn(B, 3, 3)  # random rotation matrices for test
+    "cam2rig": torch.eye(4).repeat(B, V, 1, 1)  # (B, V, 4, 4) per-view SE(3)
 }
 
 out = decoder(tokens, frames=V, metadata=metadata, cam2rig=metadata["cam2rig"])

--- a/tests/test_raymap.py
+++ b/tests/test_raymap.py
@@ -1,0 +1,186 @@
+import sys
+import traceback
+from pathlib import Path
+
+import torch
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from utils.raymap import build_raymap_targets, camera_ray_directions, patch_centers
+
+
+IMAGE_SIZE = (128, 128)
+PATCH_SIZE = 8
+GRID = IMAGE_SIZE[0] // PATCH_SIZE
+P = GRID * GRID
+
+# a 128x128 image with the principal point at the centre
+INTRINSICS = torch.tensor([[[100.0, 100.0, 64.0, 64.0]]])  # (1, 1, 4)
+
+
+def mean_axis(rays):
+    """Optical axis of a (P, 3) ray bundle: the rays fan out, so renormalize."""
+    return torch.nn.functional.normalize(rays.mean(0), dim=0)
+
+
+def identity_batch(n_views=1):
+    cam2rig = torch.eye(4).repeat(1, n_views, 1, 1)
+    world_from_rig = torch.eye(4).repeat(1, n_views, 1, 1)
+    intrinsics = INTRINSICS.repeat(1, n_views, 1)
+    return cam2rig, intrinsics, world_from_rig
+
+
+def test_patch_centers_are_row_major():
+    """Token order is row-major, so the grid must be built the same way"""
+    centers = patch_centers(IMAGE_SIZE, PATCH_SIZE, torch.device("cpu"))
+
+    assert centers.shape == (P, 2), f"Expected {(P, 2)}, got {tuple(centers.shape)}"
+    assert torch.allclose(centers[0], torch.tensor([4.0, 4.0])), "First patch centre wrong"
+    # second token steps along u (same row), not down a column
+    assert centers[1][1] == centers[0][1], "Token 1 should be in the same row as token 0"
+    assert centers[GRID][0] == centers[0][0], "Token GRID should start the next row"
+    print("✓ test_patch_centers_are_row_major passed")
+
+
+def test_principal_ray_points_forward():
+    """The ray through the principal point is the camera's forward axis"""
+    directions = camera_ray_directions(INTRINSICS, IMAGE_SIZE, PATCH_SIZE)
+
+    assert directions.shape == (1, 1, P, 3), f"Got {tuple(directions.shape)}"
+    assert torch.allclose(directions.norm(dim=-1), torch.ones(1, 1, P), atol=1e-5), (
+        "Directions should be unit length"
+    )
+    # patch centres straddle the principal point, so no ray sits exactly on it;
+    # the four central patches must be symmetric about forward = +x
+    grid = directions.reshape(GRID, GRID, 3)
+    central = grid[GRID // 2 - 1 : GRID // 2 + 1, GRID // 2 - 1 : GRID // 2 + 1]
+    mean = central.reshape(-1, 3).mean(0)
+    assert torch.allclose(mean[1:], torch.zeros(2), atol=1e-6), (
+        f"Central rays should straddle +x, got mean {mean}"
+    )
+    assert mean[0] > 0.99, f"Forward component should dominate, got {mean[0]:.3f}"
+    print("✓ test_principal_ray_points_forward passed")
+
+
+def test_image_axes_map_to_camera_axes():
+    """u grows to the right (-y in Waymo), v grows downward (-z)"""
+    directions = camera_ray_directions(INTRINSICS, IMAGE_SIZE, PATCH_SIZE)
+    grid = directions.reshape(GRID, GRID, 3)
+
+    left, right = grid[GRID // 2, 0], grid[GRID // 2, -1]
+    top, bottom = grid[0, GRID // 2], grid[-1, GRID // 2]
+
+    assert left[1] > 0 > right[1], f"Left ray should have +y, got {left[1]:.3f} / {right[1]:.3f}"
+    assert top[2] > 0 > bottom[2], f"Top ray should have +z, got {top[2]:.3f} / {bottom[2]:.3f}"
+    print("✓ test_image_axes_map_to_camera_axes passed")
+
+
+def test_rig_origin_is_camera_mount():
+    """rig_raymap origins are the camera positions in the rig frame"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    mount = torch.tensor([1.5, -0.1, 2.1])
+    cam2rig[0, 1, :3, 3] = mount
+
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+    origins = targets["rig_raymap"][..., :3]
+
+    assert targets["rig_raymap"].shape == (1, 2, P, 6), f"Got {tuple(targets['rig_raymap'].shape)}"
+    assert torch.allclose(origins[0, 0], torch.zeros(3)), "View 0 sits at the rig origin"
+    assert torch.allclose(origins[0, 1], mount.expand(P, 3)), "View 1 origin should be its mount"
+    print("✓ test_rig_origin_is_camera_mount passed")
+
+
+def test_rig_rotation_is_applied():
+    """A camera rotated on the rig produces rays rotated in the rig frame"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    # yaw view 1 by 90 degrees: camera +x (forward) becomes rig +y
+    cam2rig[0, 1, :3, :3] = torch.tensor([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+    directions = targets["rig_raymap"][..., 3:]
+
+    unrotated = mean_axis(directions[0, 0])
+    rotated = mean_axis(directions[0, 1])
+    assert unrotated[0] > 0.99, f"View 0 should look along +x, got {unrotated}"
+    assert rotated[1] > 0.99, f"View 1 should look along +y, got {rotated}"
+    print("✓ test_rig_rotation_is_applied passed")
+
+
+def test_pose_raymap_is_relative_to_first_view():
+    """Pose targets are expressed in view 0's frame, so view 0 is always canonical"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    world_from_rig[0, 0, :3, 3] = torch.tensor([10.0, 5.0, 0.0])  # anywhere in the world
+    world_from_rig[0, 1, :3, 3] = torch.tensor([14.0, 5.0, 0.0])  # rig drove 4 m forward
+
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+    pose = targets["pose_raymap"]
+    camera = camera_ray_directions(intrinsics, IMAGE_SIZE, PATCH_SIZE)
+
+    assert pose.shape == (1, 2, P, 3), f"Got {tuple(pose.shape)}"
+    assert torch.allclose(pose[0, 0], camera[0, 0], atol=1e-5), (
+        "View 0 in its own frame should equal its camera-frame rays"
+    )
+    # pure translation leaves directions unchanged; only rotation turns them
+    assert torch.allclose(pose[0, 1], camera[0, 1], atol=1e-5), (
+        "Translation alone should not rotate ray directions"
+    )
+    print("✓ test_pose_raymap_is_relative_to_first_view passed")
+
+
+def test_pose_raymap_sees_rig_rotation():
+    """A turning rig must change the pose targets, or there is nothing to learn"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    world_from_rig[0, 1, :3, :3] = torch.tensor(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+    )
+
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+    pose = targets["pose_raymap"]
+
+    assert not torch.allclose(pose[0, 0], pose[0, 1], atol=1e-3), (
+        "Pose targets are identical across a 90 degree turn - supervision is degenerate"
+    )
+    turned = mean_axis(pose[0, 1])
+    assert turned[1] > 0.99, f"View 1 should look along view 0's +y, got {turned}"
+    print("✓ test_pose_raymap_sees_rig_rotation passed")
+
+
+def run_all_tests():
+    tests = [
+        test_patch_centers_are_row_major,
+        test_principal_ray_points_forward,
+        test_image_axes_map_to_camera_axes,
+        test_rig_origin_is_camera_mount,
+        test_rig_rotation_is_applied,
+        test_pose_raymap_is_relative_to_first_view,
+        test_pose_raymap_sees_rig_rotation,
+    ]
+
+    passed = 0
+    failed = 0
+
+    print("\nRunning Raymap Target Tests")
+    print("=" * 50)
+
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as e:
+            print(f"✗ {test.__name__} failed: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"✗ {test.__name__} error: {e}")
+            traceback.print_exc()
+            failed += 1
+
+    print("=" * 50)
+    print(f"\nResults: {passed} passed, {failed} failed")
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = run_all_tests()
+    sys.exit(0 if success else 1)

--- a/tests/test_raymap.py
+++ b/tests/test_raymap.py
@@ -7,7 +7,13 @@ import torch
 root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
-from utils.raymap import build_raymap_targets, camera_ray_directions, patch_centers
+from utils.raymap import (
+    build_pointmap_target,
+    build_raymap_targets,
+    camera_ray_directions,
+    patch_centers,
+    reference_from_camera,
+)
 
 
 IMAGE_SIZE = (128, 128)
@@ -146,6 +152,92 @@ def test_pose_raymap_sees_rig_rotation():
     print("✓ test_pose_raymap_sees_rig_rotation passed")
 
 
+def test_pointmap_pools_to_patch_grid():
+    """Export grid is coarser than the model's patch grid, so it must pool down"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=1)
+    export_grid = GRID * 2
+    pointmap = torch.full((1, 1, export_grid, export_grid, 3), 3.0)
+
+    points, confidence = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert points.shape == (1, 1, P, 3), f"Got {tuple(points.shape)}"
+    assert confidence.shape == (1, 1, P), f"Got {tuple(confidence.shape)}"
+    assert torch.allclose(points, torch.full((1, 1, P, 3), 3.0)), "Pooling changed the values"
+    assert torch.allclose(confidence, torch.ones(1, 1, P)), "Fully covered patches should be 1"
+    print("✓ test_pointmap_pools_to_patch_grid passed")
+
+
+def test_pointmap_confidence_tracks_coverage():
+    """Empty cells must not be averaged in as zeros, or every target drifts toward 0"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=1)
+    export_grid = GRID * 2
+    pointmap = torch.full((1, 1, export_grid, export_grid, 3), torch.nan)
+    # fill one cell of each 2x2 block with a real return
+    pointmap[:, :, ::2, ::2] = 4.0
+    # and leave one whole patch completely empty
+    pointmap[:, :, 0:2, 0:2] = torch.nan
+
+    points, confidence = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert confidence[0, 0, 0] == 0.0, "The empty patch should have zero confidence"
+    assert torch.allclose(points[0, 0, 0], torch.zeros(3)), "Empty patches should be zeroed"
+    assert torch.allclose(confidence[0, 0, 1], torch.tensor(0.25)), (
+        f"One of four cells covered should be 0.25, got {confidence[0, 0, 1]}"
+    )
+    assert torch.allclose(points[0, 0, 1], torch.full((3,), 4.0)), (
+        f"Covered cell should survive averaging, got {points[0, 0, 1]}"
+    )
+    print("✓ test_pointmap_confidence_tracks_coverage passed")
+
+
+def test_pointmap_moves_into_reference_frame():
+    """Points arrive in each camera's own frame and must land in view 0's"""
+    cam2rig, _, world_from_rig = identity_batch(n_views=2)
+    world_from_rig[0, 1, :3, 3] = torch.tensor([4.0, 0.0, 0.0])  # view 1 is 4 m ahead
+
+    pointmap = torch.full((1, 2, GRID, GRID, 3), 0.0)
+    pointmap[..., 0] = 10.0  # both views see something 10 m down their own +x
+
+    points, _ = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+
+    assert torch.allclose(points[0, 0, :, 0], torch.full((P,), 10.0)), "View 0 is the reference"
+    assert torch.allclose(points[0, 1, :, 0], torch.full((P,), 14.0)), (
+        f"View 1's point should be 14 m out in view 0's frame, got {points[0, 1, 0]}"
+    )
+    print("✓ test_pointmap_moves_into_reference_frame passed")
+
+
+def test_pointmap_lies_along_its_own_rays():
+    """The end-to-end invariant: a target point sits on the ray of its own patch"""
+    cam2rig, intrinsics, world_from_rig = identity_batch(n_views=2)
+    cam2rig[0, 1, :3, 3] = torch.tensor([0.0, 1.0, 0.0])  # view 1 mounted a metre left
+    world_from_rig[0, 1, :3, 3] = torch.tensor([2.0, 0.0, 0.0])
+
+    # place a point 12 m along each patch's own camera ray
+    directions = camera_ray_directions(intrinsics, IMAGE_SIZE, PATCH_SIZE)
+    pointmap = (directions * 12.0).reshape(1, 2, GRID, GRID, 3)
+
+    points, _ = build_pointmap_target(
+        pointmap, cam2rig, world_from_rig, PATCH_SIZE, IMAGE_SIZE
+    )
+    targets = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+
+    centers = reference_from_camera(cam2rig, world_from_rig)[..., :3, 3]
+    for view in range(2):
+        offset = points[0, view] - centers[0, view]
+        cosine = torch.nn.functional.cosine_similarity(
+            offset, targets["pose_raymap"][0, view], dim=-1
+        )
+        assert cosine.min() > 0.9999, f"View {view} points drift off their rays: {cosine.min()}"
+    print("✓ test_pointmap_lies_along_its_own_rays passed")
+
+
 def run_all_tests():
     tests = [
         test_patch_centers_are_row_major,
@@ -155,6 +247,10 @@ def run_all_tests():
         test_rig_rotation_is_applied,
         test_pose_raymap_is_relative_to_first_view,
         test_pose_raymap_sees_rig_rotation,
+        test_pointmap_pools_to_patch_grid,
+        test_pointmap_confidence_tracks_coverage,
+        test_pointmap_moves_into_reference_frame,
+        test_pointmap_lies_along_its_own_rays,
     ]
 
     passed = 0

--- a/tests/test_rig3r_forward.py
+++ b/tests/test_rig3r_forward.py
@@ -22,8 +22,7 @@ def test_rig3r_forward():
 
     # Optional dummy metadata
     metadata = {
-        "cam2rig": torch.eye(3).unsqueeze(0).repeat(B, 1, 1)  # (B, 3, 3)
-        # "cam2rig": torch.eye(3).unsqueeze(0).repeat(B, 3)  # (B, 3, 3)
+        "cam2rig": torch.eye(4).repeat(B, N, 1, 1)  # (B, V, 4, 4) per-view SE(3)
     }
 
     # Initialize model

--- a/tests/test_waymo.py
+++ b/tests/test_waymo.py
@@ -30,11 +30,18 @@ def mock_cam2rig(index):
     return transform
 
 
+def mock_world_from_rig(index):
+    """A rig driving straight along world +x, one metre per frame."""
+    transform = torch.eye(4)
+    transform[0, 3] = float(index)
+    return transform
+
+
 def create_mock_waymo_dataset(tmp_path):
     """
     Creates a minimal mock waymo JPEG tree for testing.
     Matches ops/parquet2jpeg.py output: root/split/segment/CAMERA/<timestamp>.jpeg
-    plus root/split/segment/calibration.json
+    plus root/split/segment/{calibration,poses}.json
     """
     for split in SPLITS:
         for sequence_id in SEQUENCE_IDS:
@@ -55,8 +62,14 @@ def create_mock_waymo_dataset(tmp_path):
                 }
                 for i, camera in enumerate(CAMERAS)
             }
-            path = tmp_path / split / sequence_id / "calibration.json"
-            path.write_text(json.dumps(calibration))
+            segment_dir = tmp_path / split / sequence_id
+            (segment_dir / "calibration.json").write_text(json.dumps(calibration))
+
+            poses = {
+                str(timestamp): mock_world_from_rig(i).flatten().tolist()
+                for i, timestamp in enumerate(TIMESTAMPS)
+            }
+            (segment_dir / "poses.json").write_text(json.dumps(poses))
 
     return tmp_path
 
@@ -141,6 +154,51 @@ def test_cam2rig_follows_camera_order(mock_data):
     expected = torch.stack([mock_cam2rig(CAMERAS.index(c)) for c in cameras])
     assert torch.allclose(cam2rig, expected), f"cam2rig out of order: {cam2rig[:, 0, 3]}"
     print("✓ test_cam2rig_follows_camera_order passed")
+
+
+@with_mock_dataset
+def test_intrinsics_scaled_to_image_size(mock_data):
+    """Intrinsics are exported at native resolution, so the loader must rescale"""
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=1, image_size=(64, 64))
+    intrinsics = dataset[0]["intrinsics"]
+
+    assert intrinsics.shape == (len(CAMERAS), 4), f"Got {tuple(intrinsics.shape)}"
+    # mock calibration is f=2000, c=(960, 640) at 1920x1280 -> 64x64
+    expected = torch.tensor([2000 / 30, 2000 / 20, 960 / 30, 640 / 20])
+    assert torch.allclose(intrinsics[0], expected), f"Expected {expected}, got {intrinsics[0]}"
+    print("✓ test_intrinsics_scaled_to_image_size passed")
+
+
+@with_mock_dataset
+def test_world_from_rig_is_per_frame(mock_data):
+    """Rig pose varies per timestamp and is shared by every camera in that frame"""
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    world_from_rig = dataset[0]["world_from_rig"]
+
+    n_cameras = len(CAMERAS)
+    assert world_from_rig.shape == (2 * n_cameras, 4, 4), f"Got {tuple(world_from_rig.shape)}"
+    assert torch.allclose(world_from_rig[:n_cameras], world_from_rig[0]), (
+        "All cameras in a frame share one rig pose"
+    )
+    displacement = world_from_rig[n_cameras, 0, 3] - world_from_rig[0, 0, 3]
+    assert displacement != 0, "Rig pose should differ between frames, or pose targets are static"
+    print("✓ test_world_from_rig_is_per_frame passed")
+
+
+@with_mock_dataset
+def test_dataset_missing_poses(mock_data):
+    """A segment exported before pose support fails loudly, not silently"""
+    for path in mock_data.glob("train/*/poses.json"):
+        path.unlink()
+
+    error_raised = False
+    try:
+        WaymoDataset(root_dir=mock_data, split="train")
+    except ValueError as e:
+        error_raised = "Poses not found" in str(e)
+
+    assert error_raised, "Should raise ValueError when poses.json is missing"
+    print("✓ test_dataset_missing_poses passed")
 
 
 @with_mock_dataset
@@ -262,6 +320,9 @@ def run_all_tests():
         test_dataset_getitem,
         test_cam2rig_is_real_calibration,
         test_cam2rig_follows_camera_order,
+        test_intrinsics_scaled_to_image_size,
+        test_world_from_rig_is_per_frame,
+        test_dataset_missing_poses,
         test_dataset_missing_calibration,
         test_images_are_decoded_pixels,
         test_dataset_n_frames,

--- a/tests/test_waymo.py
+++ b/tests/test_waymo.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 import traceback
 
+import numpy
 import torch
 from PIL import Image
 
@@ -37,6 +38,18 @@ def mock_world_from_rig(index):
     return transform
 
 
+POINTMAP_GRID = 8
+
+
+def mock_pointmap():
+    """(n_timestamps, G, G, 3) with the bottom half empty, as lidar tends to be."""
+    grid = numpy.full(
+        (len(TIMESTAMPS), POINTMAP_GRID, POINTMAP_GRID, 3), numpy.nan, dtype=numpy.float16
+    )
+    grid[:, : POINTMAP_GRID // 2] = 5.0
+    return grid
+
+
 def create_mock_waymo_dataset(tmp_path):
     """
     Creates a minimal mock waymo JPEG tree for testing.
@@ -66,10 +79,20 @@ def create_mock_waymo_dataset(tmp_path):
             (segment_dir / "calibration.json").write_text(json.dumps(calibration))
 
             poses = {
-                str(timestamp): mock_world_from_rig(i).flatten().tolist()
+                str(timestamp): {
+                    camera: mock_world_from_rig(i).flatten().tolist() for camera in CAMERAS
+                }
                 for i, timestamp in enumerate(TIMESTAMPS)
             }
             (segment_dir / "poses.json").write_text(json.dumps(poses))
+
+            pointmap_dir = segment_dir / "pointmap"
+            pointmap_dir.mkdir(exist_ok=True)
+            for camera in CAMERAS:
+                numpy.save(pointmap_dir / f"{camera}.npy", mock_pointmap())
+            (pointmap_dir / "timestamps.json").write_text(
+                json.dumps([str(timestamp) for timestamp in TIMESTAMPS])
+            )
 
     return tmp_path
 
@@ -183,6 +206,35 @@ def test_world_from_rig_is_per_frame(mock_data):
     displacement = world_from_rig[n_cameras, 0, 3] - world_from_rig[0, 0, 3]
     assert displacement != 0, "Rig pose should differ between frames, or pose targets are static"
     print("✓ test_world_from_rig_is_per_frame passed")
+
+
+@with_mock_dataset
+def test_pointmap_is_loaded_per_view(mock_data):
+    """Lidar pointmaps line up one-per-view and keep their empty cells as NaN"""
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    pointmap = dataset[0]["pointmap"]
+
+    n_views = 2 * len(CAMERAS)
+    assert pointmap.shape == (n_views, POINTMAP_GRID, POINTMAP_GRID, 3), (
+        f"Got {tuple(pointmap.shape)}"
+    )
+    assert torch.isnan(pointmap[:, POINTMAP_GRID // 2 :]).all(), "Empty cells should stay NaN"
+    assert not torch.isnan(pointmap[:, : POINTMAP_GRID // 2]).any(), "Filled cells lost"
+    print("✓ test_pointmap_is_loaded_per_view passed")
+
+
+@with_mock_dataset
+def test_pointmap_is_optional(mock_data):
+    """A tree exported before lidar support still loads, just without pointmaps"""
+    for path in mock_data.glob("train/*/pointmap"):
+        shutil.rmtree(path)
+
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    sample = dataset[0]
+
+    assert sample["pointmap"].numel() == 0, "Missing pointmaps should give an empty tensor"
+    assert sample["images"].shape[0] == 2 * len(CAMERAS), "Images should still load"
+    print("✓ test_pointmap_is_optional passed")
 
 
 @with_mock_dataset
@@ -322,6 +374,8 @@ def run_all_tests():
         test_cam2rig_follows_camera_order,
         test_intrinsics_scaled_to_image_size,
         test_world_from_rig_is_per_frame,
+        test_pointmap_is_loaded_per_view,
+        test_pointmap_is_optional,
         test_dataset_missing_poses,
         test_dataset_missing_calibration,
         test_images_are_decoded_pixels,

--- a/tests/test_waymo.py
+++ b/tests/test_waymo.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -22,10 +23,18 @@ TIMESTAMPS = [1550083470045260 + i for i in range(10)]
 TMP_PATH = Path("tmp_test_data")
 
 
+def mock_cam2rig(index):
+    """Distinct SE(3) per camera so tests can tell the rig apart from identity."""
+    transform = torch.eye(4)
+    transform[0, 3] = float(index)
+    return transform
+
+
 def create_mock_waymo_dataset(tmp_path):
     """
     Creates a minimal mock waymo JPEG tree for testing.
     Matches ops/parquet2jpeg.py output: root/split/segment/CAMERA/<timestamp>.jpeg
+    plus root/split/segment/calibration.json
     """
     for split in SPLITS:
         for sequence_id in SEQUENCE_IDS:
@@ -37,6 +46,17 @@ def create_mock_waymo_dataset(tmp_path):
                     Image.new("RGB", (32, 24), color=(10, 20, 30)).save(
                         camera_dir / f"{timestamp}.jpeg"
                     )
+
+            calibration = {
+                camera: {
+                    "cam2rig": mock_cam2rig(i).flatten().tolist(),
+                    "f_u": 2000.0, "f_v": 2000.0, "c_u": 960.0, "c_v": 640.0,
+                    "width": 1920, "height": 1280,
+                }
+                for i, camera in enumerate(CAMERAS)
+            }
+            path = tmp_path / split / sequence_id / "calibration.json"
+            path.write_text(json.dumps(calibration))
 
     return tmp_path
 
@@ -89,12 +109,54 @@ def test_dataset_getitem(mock_data):
     assert sample["images"].shape == (n_views, 3, 64, 64), (
         f"Expected images {(n_views, 3, 64, 64)}, got {tuple(sample['images'].shape)}"
     )
-    assert sample["metadata"]["cam2rig"].shape == (n_views * 3, 3), (
-        f"Expected cam2rig {(n_views * 3, 3)}, got {tuple(sample['metadata']['cam2rig'].shape)}"
+    assert sample["metadata"]["cam2rig"].shape == (n_views, 4, 4), (
+        f"Expected cam2rig {(n_views, 4, 4)}, got {tuple(sample['metadata']['cam2rig'].shape)}"
     )
     assert sample["segment_id"] in SEQUENCE_IDS, "Sample should report its segment"
     assert len(sample["timestamps"]) == 2, "Sample should carry one timestamp per frame"
     print("✓ test_dataset_getitem passed")
+
+
+@with_mock_dataset
+def test_cam2rig_is_real_calibration(mock_data):
+    """Guard against identity extrinsics: cam2rig must come from calibration.json"""
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=2)
+    cam2rig = dataset[0]["metadata"]["cam2rig"]
+
+    expected = torch.stack([mock_cam2rig(i) for i in range(len(CAMERAS))])
+    assert torch.allclose(cam2rig[: len(CAMERAS)], expected), "cam2rig does not match calibration.json"
+    # rig is rigid: the same block repeats for every frame in the window
+    assert torch.allclose(cam2rig[len(CAMERAS) :], expected), "cam2rig should tile over frames"
+    assert not torch.allclose(cam2rig, torch.eye(4)), "cam2rig collapsed back to identity"
+    print("✓ test_cam2rig_is_real_calibration passed")
+
+
+@with_mock_dataset
+def test_cam2rig_follows_camera_order(mock_data):
+    """cam2rig rows must line up with the cameras the images were stacked in"""
+    cameras = ["SIDE_RIGHT", "FRONT"]
+    dataset = WaymoDataset(root_dir=mock_data, split="train", cameras=cameras, n_frames=1)
+    cam2rig = dataset[0]["metadata"]["cam2rig"]
+
+    expected = torch.stack([mock_cam2rig(CAMERAS.index(c)) for c in cameras])
+    assert torch.allclose(cam2rig, expected), f"cam2rig out of order: {cam2rig[:, 0, 3]}"
+    print("✓ test_cam2rig_follows_camera_order passed")
+
+
+@with_mock_dataset
+def test_dataset_missing_calibration(mock_data):
+    """A segment exported before calibration support fails loudly, not silently"""
+    for path in mock_data.glob("train/*/calibration.json"):
+        path.unlink()
+
+    error_raised = False
+    try:
+        WaymoDataset(root_dir=mock_data, split="train")
+    except ValueError as e:
+        error_raised = "Calibration not found" in str(e)
+
+    assert error_raised, "Should raise ValueError when calibration.json is missing"
+    print("✓ test_dataset_missing_calibration passed")
 
 
 @with_mock_dataset
@@ -198,6 +260,9 @@ def run_all_tests():
         test_dataset_initialization,
         test_dataset_splits,
         test_dataset_getitem,
+        test_cam2rig_is_real_calibration,
+        test_cam2rig_follows_camera_order,
+        test_dataset_missing_calibration,
         test_images_are_decoded_pixels,
         test_dataset_n_frames,
         test_dataset_camera_subset,

--- a/utils/raymap.py
+++ b/utils/raymap.py
@@ -1,0 +1,77 @@
+"""Raymap ground truth from camera calibration and rig poses.
+
+The model's raymap heads predict one ray per patch token, so the targets are
+built on the same patch grid: `pose_raymap` as unit directions relative to the
+first view, `rig_raymap` as (origin, direction) in the rig frame.
+
+Waymo camera convention: x forward, y left, z up, with
+    u = f_u * (-y / x) + c_u
+    v = f_v * (-z / x) + c_v
+so a pixel back-projects to [1, -(u - c_u) / f_u, -(v - c_v) / f_v].
+"""
+
+import torch
+
+
+def patch_centers(image_size, patch_size, device):
+    """Pixel centres of each patch, row-major to match ViT token order. (P, 2)"""
+    height, width = image_size
+    rows = (torch.arange(height // patch_size, device=device) + 0.5) * patch_size
+    cols = (torch.arange(width // patch_size, device=device) + 0.5) * patch_size
+    v, u = torch.meshgrid(rows, cols, indexing="ij")
+    return torch.stack([u.reshape(-1), v.reshape(-1)], dim=-1)
+
+
+def camera_ray_directions(intrinsics, image_size, patch_size):
+    """Unit ray directions in each camera's own frame.
+
+    Args:
+        intrinsics: (B, V, 4) as [f_u, f_v, c_u, c_v], scaled to image_size
+        image_size: (H, W) of the images actually fed to the model
+        patch_size: model patch size
+    Returns:
+        (B, V, P, 3)
+    """
+    centers = patch_centers(image_size, patch_size, intrinsics.device)  # (P, 2)
+    u, v = centers[:, 0], centers[:, 1]
+
+    f_u, f_v, c_u, c_v = (intrinsics[..., i].unsqueeze(-1) for i in range(4))
+    y = -(u - c_u) / f_u  # broadcasts (B, V, 1) against (P,) -> (B, V, P)
+    z = -(v - c_v) / f_v
+    directions = torch.stack([torch.ones_like(y), y, z], dim=-1)
+    return torch.nn.functional.normalize(directions, dim=-1)
+
+
+def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_size):
+    """Targets for the rig and pose raymap heads.
+
+    Args:
+        cam2rig:        (B, V, 4, 4) vehicle_from_camera
+        intrinsics:     (B, V, 4) [f_u, f_v, c_u, c_v] scaled to image_size
+        world_from_rig: (B, V, 4, 4) world_from_vehicle at each view's timestamp
+        image_size:     (H, W)
+        patch_size:     model patch size
+    Returns:
+        {"rig_raymap": (B, V, P, 6), "pose_raymap": (B, V, P, 3)}
+    """
+    directions = camera_ray_directions(intrinsics, image_size, patch_size)
+
+    # --- rig frame: origin is the camera's mounting point, static per camera ---
+    rotation = cam2rig[..., :3, :3]
+    translation = cam2rig[..., :3, 3]
+    rig_directions = torch.einsum("bvij,bvpj->bvpi", rotation, directions)
+    rig_origins = translation.unsqueeze(2).expand_as(rig_directions)
+    rig_raymap = torch.cat([rig_origins, rig_directions], dim=-1)
+
+    # --- pose frame: relative to view 0, so rig motion shows up in the target ---
+    world_from_camera = world_from_rig @ cam2rig
+    reference_from_world = torch.linalg.inv(world_from_camera[:, :1])
+    reference_from_camera = reference_from_world @ world_from_camera
+    pose_directions = torch.einsum(
+        "bvij,bvpj->bvpi", reference_from_camera[..., :3, :3], directions
+    )
+
+    return {
+        "rig_raymap": rig_raymap,
+        "pose_raymap": torch.nn.functional.normalize(pose_directions, dim=-1),
+    }

--- a/utils/raymap.py
+++ b/utils/raymap.py
@@ -1,4 +1,4 @@
-"""Raymap ground truth from camera calibration and rig poses.
+"""Geometric ground truth from camera calibration and rig poses.
 
 The model's raymap heads predict one ray per patch token, so the targets are
 built on the same patch grid: `pose_raymap` as unit directions relative to the
@@ -42,6 +42,44 @@ def camera_ray_directions(intrinsics, image_size, patch_size):
     return torch.nn.functional.normalize(directions, dim=-1)
 
 
+def reference_from_camera(cam2rig, world_from_rig):
+    """Each view's camera pose relative to view 0. (B, V, 4, 4)"""
+    world_from_camera = world_from_rig @ cam2rig
+    return torch.linalg.inv(world_from_camera[:, :1]) @ world_from_camera
+
+
+def build_pointmap_target(pointmap, cam2rig, world_from_rig, patch_size, image_size):
+    """Sparse per-camera lidar pointmaps -> pointmap target in view 0's frame.
+
+    Args:
+        pointmap:       (B, V, G, G, 3) points in each view's own camera frame,
+                        NaN where no lidar return landed
+        cam2rig:        (B, V, 4, 4)
+        world_from_rig: (B, V, 4, 4)
+        patch_size:     model patch size
+        image_size:     (H, W)
+    Returns:
+        (points, confidence) of shape (B, V, P, 3) and (B, V, P), confidence being
+        the fraction of cells in each patch that carried a return.
+    """
+    B, V, G, _, _ = pointmap.shape
+    grid = image_size[0] // patch_size
+
+    # pool the export grid down to the patch grid, ignoring empty cells
+    blocks = pointmap.reshape(B, V, grid, G // grid, grid, G // grid, 3)
+    blocks = blocks.permute(0, 1, 2, 4, 3, 5, 6).reshape(B, V, grid * grid, -1, 3)
+    valid = ~torch.isnan(blocks[..., 0])
+    confidence = valid.float().mean(-1)
+    points = torch.nan_to_num(blocks).sum(-2) / valid.sum(-1).clamp(min=1).unsqueeze(-1)
+
+    # each view's points sit in its own camera frame; the prediction is in view 0's
+    transform = reference_from_camera(cam2rig, world_from_rig)
+    points = torch.einsum("bvij,bvpj->bvpi", transform[..., :3, :3], points)
+    points = points + transform[..., :3, 3].unsqueeze(2)
+
+    return points * (confidence > 0).unsqueeze(-1), confidence
+
+
 def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_size):
     """Targets for the rig and pose raymap heads.
 
@@ -64,12 +102,8 @@ def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_
     rig_raymap = torch.cat([rig_origins, rig_directions], dim=-1)
 
     # --- pose frame: relative to view 0, so rig motion shows up in the target ---
-    world_from_camera = world_from_rig @ cam2rig
-    reference_from_world = torch.linalg.inv(world_from_camera[:, :1])
-    reference_from_camera = reference_from_world @ world_from_camera
-    pose_directions = torch.einsum(
-        "bvij,bvpj->bvpi", reference_from_camera[..., :3, :3], directions
-    )
+    transform = reference_from_camera(cam2rig, world_from_rig)
+    pose_directions = torch.einsum("bvij,bvpj->bvpi", transform[..., :3, :3], directions)
 
     return {
         "rig_raymap": rig_raymap,


### PR DESCRIPTION

## Summary

On `main`, training on Waymo produces a loss curve but does not learn geometry.
Three things are wrong, and each hides the next:

1. `cam2rig` is `torch.eye(3)` repeated per view. The JPEG export carries no
   calibration, so the rig-aware decoder is conditioned on an identity rig.
2. There is no ground truth of any kind, so `compute_loss` returns
   `torch.tensor(0.0, requires_grad=True)` — a tensor with no `grad_fn`.
   `loss.backward()` is a no-op and the optimizer steps nothing.
3. `get_train_transforms` applies `RandomHorizontalFlip`, which would corrupt any
   geometric target introduced to fix (2).

This PR exports the calibration, pose, and lidar data that were downloaded all
along but never read, and turns them into targets for all three loss heads.

Reviewable in commit order:

| Commit | What |
| --- | --- |
| `5ca4a30` | Real `cam2rig` from the `camera_calibration` component |
| `e85501b` | Raymap targets from calibration + rig poses |
| `0b2aed9` | Pointmap targets from the `lidar` component (merged from `lidar`) |

## 1. Real extrinsics (`5ca4a30`)

`ops/parquet2jpeg.py` now writes a `calibration.json` per segment. Waymo's rig
frame *is* the vehicle frame, so the calibration component's
`extrinsic.transform` is `cam2rig` verbatim — no composition needed. Intrinsics
ride along for later; the loader rescales them from native resolution to
`image_size`.

`WaymoDataset` reads it at index time and raises if it is missing, pointing at
the export.

### Shape fix

`cam2rig` was `(V*3, 3)`. That hits the `dim() == 3` branch of `RigRaymapHead`,
which reads `cam2rig[..., :3, :3]` — camera 0's rotation applied to every view,
with all translation dropped. Correct extrinsics in that shape would have been
silently wrong.

It is now `(V, 4, 4)`, the `dim() == 4` branch, per-view R and t. This is the
shape `datasets/wayve101.py` and `utils/visualization.py` already assumed.

The decoder rejected 4-D metadata, so `_collect_metadata_tensors` now flattens
`(B, V, 4, 4)` to one 16-dim token per view and `key_projs["cam2rig"]` becomes
`Linear(16, embed_dim)`.

**This also unbreaks CO3D.** `Co3DDataset` emits `torch.eye(3)`, collating to
`(B, V, 3, 3)`, which raised `ValueError: Unsupported metadata shape` on that
same line — `dataset_type: co3d` could not run at all on `main`. It emits
`eye(4)` now.

## 2. Raymap targets (`e85501b`)

`poses.json` per segment gives `world_from_vehicle` per frame timestamp **per
camera**, taken at each camera's own trigger instant. New `utils/raymap.py`
back-projects patch centres through Waymo's camera model
(`u = f_u·(-y/x) + c_u`) and builds:

- **`rig_raymap`** `(B, V, P, 6)` — origin at the camera mount, direction rotated
  into the vehicle frame. Static per camera, which is what a rig raymap is.
- **`pose_raymap`** `(B, V, P, 3)` — unit directions relative to view 0, so rig
  motion shows up in the target.

The patch grid is row-major to match ViT token order.

### The loss

`scripts/train.py` now uses `MultiTaskLoss` from `models/losses.py`, which was
already written and imported by nothing. It skips any term missing from either
side, so Waymo trains on raymaps and CO3D on pointclouds without a branch. The
existing pointmap downsample survives as a helper.

### Guards

- `compute_loss` asserts the total is a tensor with a `grad_fn` (except under
  `no_grad`). The silent zero-loss no-op cannot come back.
- `RandomHorizontalFlip` removed from `get_train_transforms`. It flipped pixels
  without flipping targets, which makes supervision wrong rather than noisy.
  Photometric augmentation is untouched.

## 3. Lidar pointmaps (`0b2aed9`)

New `ops/parquet2pointmap.py` projects the TOP lidar into every camera:

```bash
python ops/parquet2pointmap.py --src data/waymo_mini --dst /data/waymo_mini
python ops/parquet2pointmap.py --src data/waymo_mini --verify
```

Range image → polar → cartesian → vehicle at each pixel's own time (the TOP lidar
spins across the frame) → world → each camera's own frame. Which pixel a return
lands on comes from Waymo's `lidar_camera_projection`, so only the 3D
reconstruction is ours.

Written as `pointmap/<CAMERA>.npy`, `(n_frames, 64, 64, 3)` float16, `NaN` where
nothing landed — 24 MB per segment, 240 MB for the mini set against 3.3 GB of
JPEGs. Memory-mapped and sliced per sample. Unlike the other two exports this one
is **optional**: without it training still runs on raymaps alone.

`build_pointmap_target` pools the grid to the model's patch grid ignoring `NaN`,
turns coverage into `pointmap_conf` — which `MultiTaskLoss` already supported and
nothing had ever produced — and moves each view's points into view 0's frame.

### `--verify` caught a timing bug

The first implementation used the per-frame `vehicle_pose` for all five cameras.
Reprojection error against Waymo's own projections:

| Segment | FRONT | SIDE_LEFT | SIDE_RIGHT |
| --- | --- | --- | --- |
| `10017090...6380` | 2.90 px | 36.16 px | 31.98 px |
| `10050810...5313` | 6.17 px | 35.12 px | **131.17 px** |
| `10023947...1120` | 1.62 px | 2.01 px | 1.99 px |

Front cameras fine, side cameras not, and only while the rig was moving — a
timing signature, not bad geometry. The five cameras do not trigger together, so
the fix is `[CameraImageComponent].pose.transform`, the pose at each camera's own
instant. Medians then land around 2 px, worst segment 57 px.

This is why `poses.json` is keyed per camera, and it improves the raymap targets
from commit 2 for the same reason. `vehicle_pose` is no longer read at all.

## Breaking change

Any existing export must be regenerated:

```bash
make download-waymo-mini      # or run the two ops scripts directly
```

`calibration.json` and `poses.json` are required and `WaymoDataset` raises with a
message naming the script.

## Testing

```bash
python tests/test_raymap.py    # 11 passed, new file
python tests/test_waymo.py     # 19 passed
python tests/test_loss.py
python tests/test_decoder.py
```

`test_raymap.py` covers the camera model (principal ray, image axes → camera
axes), the rig transform, that pose targets *change* under a 90° turn, pooling,
confidence vs coverage, and the end-to-end invariant that a target point lies on
the ray of its own patch. `test_waymo.py` gains calibration correctness, camera
ordering, intrinsic rescaling, per-frame poses, pointmap loading, and loud
failures for each missing export.

Verified against the real mini set:

```
cam2rig translations      z = 2.116 m roof mount, lateral spread ±0.111 m
cos(FRONT, FRONT_LEFT)    0.72   (~45° apart)
cos(FRONT, SIDE_LEFT)     0.02   (~90° apart)
cos(point - centre, ray)  0.99986 - 0.99999 across all five cameras
patch coverage 62-92%,  depth median 7.9 m
```

One epoch on one segment trains with all three terms: train 25.1, val 90.9.

## Known limitations

1. **The loss terms are badly scaled.** Measured on a real batch, `pointmap` is
   24.6 against `pose_raymap` 1.01 and `rig_raymap` 1.00 — metric MSE in metres
   against two cosine terms bounded by 2. Weights are exposed as `loss.w_point` /
   `w_pose` / `w_rig` and default to 1.0; `w_point: 0.05` brings the total to
   3.24. Left for tuning rather than guessed at here.
2. **`rig_raymap` is scale-blind.** `MultiTaskLoss` scores it by cosine over the
   concatenated `(origin, direction)` 6-vector, so absolute rig translation is
   unsupervised. Splitting it into a direction term and `camera_center_rig` would
   fix it. Pre-existing.
3. **TOP lidar only.** It covers every camera out to ~75 m; the four side lidars
   are 20 m near-field with a different beam-inclination convention. Marked with
   a `ponytail:` comment.
4. **Rolling shutter is not modelled.** The ~2 px residual is per-row camera
   readout, needing the `velocity` and `rolling_shutter_params` fields. At
   128×128 even the worst observed segment stays under half a patch, so the
   targets are quantised more coarsely than the error.
5. **Geometric augmentation is gone, not fixed.** Flips and crops would need to
   transform the targets alongside the pixels. Nothing does that yet.
