### PR TITLE
Actually load the DUSt3R encoder (292/292 tensors, was 0)

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -10,7 +10,7 @@ num_workers: 4
 epochs: 50
 n_frames: 24  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
-patch_size: 8  # must match the model; also sets the raymap target resolution
+patch_size: 16  # fixed by the DUSt3R ViT-L/16 encoder; also sets the raymap target resolution
 
 # Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
 # terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -10,7 +10,7 @@ num_workers: 4
 epochs: 1 #50
 n_frames: 2  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
-patch_size: 8  # must match the model; also sets the raymap target resolution
+patch_size: 16  # fixed by the DUSt3R ViT-L/16 encoder; also sets the raymap target resolution
 
 # Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
 # terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.

--- a/docs/VISUALIZATION.md
+++ b/docs/VISUALIZATION.md
@@ -254,7 +254,7 @@ The model returns:
 | `pose_raymap` | `(B, V, P, 3)` | Unit ray directions in camera frame (patch-level) |
 | `rig_raymap` | `(B, V, P, 6)` | Ray origins and directions in rig frame (patch-level) |
 
-`P = (image_size / patch_size)²`. For the default 128×128 image with patch size 8, `P = 256`.
+`P = (image_size / patch_size)²`. For the default 128×128 image with patch size 16, `P = 64`.
 
 ---
 

--- a/models/decoder_transformer.py
+++ b/models/decoder_transformer.py
@@ -58,7 +58,6 @@ class RigAwareTransformerDecoder(nn.Module):
             num_layers = 8,
             num_heads = 8,
             mlp_dim = 4096,
-            metadata_dim = 64,
             metadata_tokens = 1,
             metadata_dropout = 0.5,
             head_hidden = None,
@@ -68,7 +67,6 @@ class RigAwareTransformerDecoder(nn.Module):
     ):
         super().__init__()
         self.embed_dim = embed_dim
-        self.metadata_dim = metadata_dim
         self.metadata_tokens = metadata_tokens
         self.img_size = img_size
         self.patch_size = patch_size
@@ -78,8 +76,6 @@ class RigAwareTransformerDecoder(nn.Module):
             "cam2rig": nn.Linear(16, embed_dim)  # one token per view, a flattened 4x4 SE(3)
         })
 
-        # metadata projector: maps external metadata -> embed_dim tokens
-        self.meta_proj = nn.Linear(metadata_dim, embed_dim) if metadata_dim is not None else None
         # if metadata is not provided, we still support learned metadata tokens (learnable)
         self.learned_meta = nn.Parameter(torch.randn(1, metadata_tokens, embed_dim))
 
@@ -135,31 +131,26 @@ class RigAwareTransformerDecoder(nn.Module):
     def _prepare_metadata_tokens(self, metadata, batch_size, device):
         """
             Returns metadata tokens of shape (B, M, C).
-            - If metadata is provided: project it -> (B, M, C).
-            Expect metadata shape (B, M, metadata_dim). If metadata has fewer tokens,
-            it's still fine (we project element-wise).
+            - If metadata is provided: each key is projected to embed_dim by its own
+            entry in key_projs, so raw metadata widths need not match embed_dim.
             - If None: use learned tokens repeated over batch.
         """
         if metadata is None:
-            meta_tokens = self.learned_meta.expand(batch_size, -1, -1).to(device)  # (B, M, C)
-        
+            return self.learned_meta.expand(batch_size, -1, -1).to(device)  # (B, M, C)
+
         meta_list = self._collect_metadata_tensors(metadata, device)
 
         if len(meta_list) == 0:
             return self.learned_meta.expand(batch_size, -1, -1).to(device)
 
-        meta_tokens = torch.cat(meta_list, dim=1)
-
-        if self.meta_proj:
-            meta_tokens = self.meta_proj(meta_tokens)
-        
-        return self.metadata_dropout(meta_tokens)
+        return self.metadata_dropout(torch.cat(meta_list, dim=1))
     
     def forward(self, tokens, frames, metadata=None, cam2rig=None):
         """
             tokens: (B, V * P, C)
             frames: V (int)
-            metadata: Optional (B, M, metadata_dim)  (M == metadata_tokens recommended)
+            metadata: Optional dict of per-key tensors, each projected to embed_dim
+                by key_projs (e.g. cam2rig: (B, V, 4, 4))
         """
         B, T_total, C = tokens.shape
         assert C == self.embed_dim, f"tokens embed dim {C} != decoder embed_dim {self.embed_dim}"

--- a/models/encoder_vit.py
+++ b/models/encoder_vit.py
@@ -1,95 +1,81 @@
 import torch
 import argparse
+import timm
 import torch.nn as nn
-import torch.nn.functional as F
-from torchvision.models.vision_transformer import VisionTransformer
 
 # allow argparse.Namespace inside the checkpoint
 torch.serialization.add_safe_globals([argparse.Namespace])
 
+# DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth: enc_depth=24, enc_embed_dim=1024,
+# enc_num_heads=16, patch_size=16. Anything else will fail the strict load below.
+DUST3R_ENCODER = dict(patch_size=16, embed_dim=1024, depth=24, num_heads=16)
+
+
 class ViTEncoder(nn.Module):
-    def __init__(self, checkpoint_path=None, img_size=384, patch_size=8, embed_dim=1024):
+    """ViT-L/16 image encoder, optionally initialised from DUSt3R's CroCo encoder.
+
+    DUSt3R's encoder uses timm's block naming under an ``enc_`` prefix, so the
+    checkpoint drops straight into a timm ``VisionTransformer`` after a prefix
+    rename - no per-tensor remap, no qkv surgery.
+    """
+
+    def __init__(
+        self,
+        checkpoint_path=None,
+        img_size=384,
+        patch_size=16,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        freeze=True,
+    ):
         super().__init__()
-        # Load pretrained ViT-Large architecture
-        self.vit = VisionTransformer(
-            image_size=img_size,
+        self.vit = timm.models.VisionTransformer(
+            img_size=img_size,
             patch_size=patch_size,
-            num_layers=24,
-            num_heads=8,
-            hidden_dim=embed_dim,
-            mlp_dim=4096,
-            num_classes=0
+            embed_dim=embed_dim,
+            depth=depth,
+            num_heads=num_heads,
+            class_token=False,
+            global_pool="",
+            num_classes=0,
+            # ponytail: no positional signal at all right now, so the encoder is
+            # permutation-equivariant over patches. Rig3R sec 3.3 specifies 2D
+            # sine-cosine (not the checkpoint's RoPE100) - see issue #42.
+            pos_embed="none",
         )
 
-        # Replace positional embedding with sinusoidal (frozen)
-        num_patches = self.vit.dump_patches
-        self.vit.pos_embed = nn.Parameter(
-            self._build_sinusoidal_pos_embed(num_patches, embed_dim), requires_grad=False
-        )
-
-        # Load DUST3R weights
-        # Optional: load DUSt3R weights for other parameters if provided
         if checkpoint_path is not None:
-            state_dict = torch.load(checkpoint_path, map_location="cpu")
-            self._load_dust3r_weights(state_dict)
+            self._load_dust3r_weights(checkpoint_path)
 
-        # LayerNorm for output normalization
-        self.norm = nn.LayerNorm(embed_dim)
+        # 300M frozen params cost ~1.2 GiB of activations for 128 views; trainable
+        # they cost ~5 GiB of optimizer state on top and will not fit a 12 GB card.
+        if freeze:
+            self.vit.requires_grad_(False)
 
-    def _build_sinusoidal_pos_embed(self, num_patches, dim):
-        # Standard 2D sinusoidal positional encoding
-        H = W = int(num_patches ** 0.5)
-        grid_y, grid_x = torch.meshgrid(torch.arange(H), torch.arange(W), indexing='ij')
-        grid = torch.stack([grid_x, grid_y], dim=-1).float() # shape (H, W, 2)
+    def _load_dust3r_weights(self, checkpoint_path):
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        # DUSt3R wraps the weights: the file is {"model": ..., "args": ...}
+        state_dict = checkpoint.get("model", checkpoint)
 
-        pos_embed = torch.zeros(H, W, dim)
-        div_term = torch.exp(torch.arange(0, dim, 4).float() * -(torch.log(torch.tensor(10000.0)) / dim))
-        pos_embed[:, :, 0::4] = torch.sin(grid[:, :, 0:1] * div_term)
-        pos_embed[:, :, 1::4] = torch.cos(grid[:, :, 0:1] * div_term)
-        pos_embed[:, :, 2::4] = torch.sin(grid[:, :, 1:2] * div_term)
-        pos_embed[:, :, 3::4] = torch.cos(grid[:, :, 1:2] * div_term)
+        # CroCo: patch_embed.* / enc_blocks.N.* / enc_norm.*
+        # timm:  patch_embed.* / blocks.N.*     / norm.*
+        encoder_weights = {
+            key.replace("enc_blocks.", "blocks.").replace("enc_norm.", "norm."): value
+            for key, value in state_dict.items()
+            if key.startswith(("patch_embed.", "enc_blocks.", "enc_norm."))
+        }
+        if not encoder_weights:
+            raise ValueError(
+                f"No encoder weights (patch_embed./enc_blocks./enc_norm.) in {checkpoint_path}. "
+                f"Top-level keys: {sorted(state_dict)[:10]}"
+            )
 
-        pos_embed = pos_embed.reshape(1, H * W, dim)
-        cls_token = torch.zeros(1, 1, dim) # [CLS] token
-        return torch.cat([cls_token, pos_embed], dim=1)
-
-    def _embed_patches(self, x):
-        B = x.shape[0]
-
-        # Patch embedding
-        tokens = self.vit.conv_proj(x) # (B, N, C)
-        # Flatten spatial dims and transpose to (B, N, C)
-        B, C, H_p, W_p = tokens.shape
-        tokens = tokens.flatten(2).transpose(1, 2)
-        # Prepend [CLS] token
-        cls_token = self.vit.class_token.expand(B, -1, -1) # (B, 1, C)
-        tokens = torch.cat((cls_token, tokens), dim=1) # (B, N+1, C)
-
-        # Add positional embedding
-        tokens = tokens + self.vit.pos_embed.to(tokens.device)
-        return tokens
-
-    def _tokens_to_feature_map(self, patch_tokens):
-        # Reshape tokens into a spatial feature map
-        B, N, C = patch_tokens.shape
-        H = W = int(N ** 0.5)
-        return patch_tokens.transpose(1, 2).reshape(B, C, H, W)
-    
-    def _load_dust3r_weights(self, state_dict):
-        # Load pretrained weights for parameters other than pos_embed
-        state_dict.pop("pos_embed", None) # Remove pos_embed to keep sinusoidal
-        msg = self.vit.load_state_dict(state_dict, strict=False)
-        print("Loaded DUSt3R weights (excluding pos_embed)")
-        # print("Loaded DUSt3R weights (excluding pos_embed):", msg)
+        # strict: a silent no-op load is the bug this replaces. Any name or shape
+        # drift - wrong embed_dim, wrong patch_size - must raise, not print.
+        self.vit.load_state_dict(encoder_weights, strict=True)
+        print(f"Loaded {len(encoder_weights)} DUSt3R encoder tensors from {checkpoint_path}")
 
     def forward(self, x):
-
-        tokens = self._embed_patches(x)
-        tokens = self.vit.encoder(tokens)
-        patch_tokens = tokens[:, 1:, :]
-        feature_map = self._tokens_to_feature_map(patch_tokens)
-        
-        return {
-            "tokens": self.norm(patch_tokens),
-            "feature_map": feature_map
-        }
+        # forward_features applies patch embed + blocks + the loaded enc_norm
+        return {"tokens": self.vit.forward_features(x)}  # (B, P, C)

--- a/models/encoder_vit.py
+++ b/models/encoder_vit.py
@@ -2,6 +2,7 @@ import torch
 import argparse
 import timm
 import torch.nn as nn
+from timm.layers.pos_embed_sincos import build_sincos2d_pos_embed
 
 # allow argparse.Namespace inside the checkpoint
 torch.serialization.add_safe_globals([argparse.Namespace])
@@ -39,10 +40,15 @@ class ViTEncoder(nn.Module):
             class_token=False,
             global_pool="",
             num_classes=0,
-            # ponytail: no positional signal at all right now, so the encoder is
-            # permutation-equivariant over patches. Rig3R sec 3.3 specifies 2D
-            # sine-cosine (not the checkpoint's RoPE100) - see issue #42.
-            pos_embed="none",
+            pos_embed="learn",  # overwritten below with a fixed sine-cosine table
+        )
+
+        # Rig3R sec 3.3 encodes patches with 2D sine-cosine, not the checkpoint's
+        # RoPE100, so this table is generated rather than loaded and stays frozen
+        # even when the rest of the encoder is fine-tuned.
+        self.vit.pos_embed = nn.Parameter(
+            build_sincos2d_pos_embed(self.vit.patch_embed.grid_size, embed_dim).unsqueeze(0),
+            requires_grad=False,
         )
 
         if checkpoint_path is not None:
@@ -71,10 +77,15 @@ class ViTEncoder(nn.Module):
                 f"Top-level keys: {sorted(state_dict)[:10]}"
             )
 
+        # pos_embed is ours (sine-cosine, sec 3.3), not DUSt3R's - carry the one built
+        # in __init__ through so the load below can stay strict.
+        loaded = len(encoder_weights)
+        encoder_weights["pos_embed"] = self.vit.pos_embed
+
         # strict: a silent no-op load is the bug this replaces. Any name or shape
         # drift - wrong embed_dim, wrong patch_size - must raise, not print.
         self.vit.load_state_dict(encoder_weights, strict=True)
-        print(f"Loaded {len(encoder_weights)} DUSt3R encoder tensors from {checkpoint_path}")
+        print(f"Loaded {loaded} DUSt3R encoder tensors from {checkpoint_path}")
 
     def forward(self, x):
         # forward_features applies patch embed + blocks + the loaded enc_norm

--- a/models/heads/pointmap_head.py
+++ b/models/heads/pointmap_head.py
@@ -67,10 +67,12 @@ class PointMapHead(nn.Module):
         # Project from token dim to hidden dim
         self.input_proj = nn.Conv2d(in_dim, hidden_dim, kernel_size=1)
 
-        # 3 Fusion blocks for 8x upsampling (48 → 96 → 192 → 384)
-        self.fusion1 = FusionBlock(hidden_dim)
-        self.fusion2 = FusionBlock(hidden_dim)
-        self.fusion3 = FusionBlock(hidden_dim)
+        # Each fusion block upsamples 2x, so it takes log2(patch_size) of them to get
+        # the patch grid back to image resolution: 8 -> 3 blocks, 16 -> 4 blocks.
+        num_fusion = patch_size.bit_length() - 1
+        if 2 ** num_fusion != patch_size:
+            raise ValueError(f"patch_size must be a power of 2, got {patch_size}")
+        self.fusion = nn.ModuleList(FusionBlock(hidden_dim) for _ in range(num_fusion))
 
         # Output heads: 3 channels for XYZ pointmap, 1 channel for confidence
         self.output_conv = nn.Conv2d(hidden_dim, 4, kernel_size=1)
@@ -95,16 +97,13 @@ class PointMapHead(nn.Module):
         # Project to hidden dimension
         x = self.input_proj(x)  # (B*V, hidden_dim, 48, 48)
 
-        # Progressive upsampling through fusion blocks
+        # Progressive 2x upsampling, e.g. 48 -> 96 -> 192 -> 384
         # Use gradient checkpointing during training to reduce memory usage
-        if self.training and self.use_gradient_checkpointing:
-            x = checkpoint(self.fusion1, x, use_reentrant=False)  # (B*V, hidden_dim, 96, 96)
-            x = checkpoint(self.fusion2, x, use_reentrant=False)  # (B*V, hidden_dim, 192, 192)
-            x = checkpoint(self.fusion3, x, use_reentrant=False)  # (B*V, hidden_dim, 384, 384)
-        else:
-            x = self.fusion1(x)  # (B*V, hidden_dim, 96, 96)
-            x = self.fusion2(x)  # (B*V, hidden_dim, 192, 192)
-            x = self.fusion3(x)  # (B*V, hidden_dim, 384, 384)
+        for fusion in self.fusion:
+            if self.training and self.use_gradient_checkpointing:
+                x = checkpoint(fusion, x, use_reentrant=False)
+            else:
+                x = fusion(x)
 
         # Output projection
         out = self.output_conv(x)  # (B*V, 4, 384, 384)

--- a/models/rig3r.py
+++ b/models/rig3r.py
@@ -12,12 +12,12 @@ class Rig3R(nn.Module):
         self,
         encoder_ckpt=None,
         img_size=384,
-        patch_size=8,
+        patch_size=16,
         embed_dim=1024,
-        metadata_dim=64,
         num_decoder_layers=6,
         num_heads=8,
-        mlp_dim=2048
+        mlp_dim=2048,
+        freeze_encoder=True
     ):
         super().__init__()
 
@@ -26,7 +26,8 @@ class Rig3R(nn.Module):
             checkpoint_path=encoder_ckpt,
             img_size=img_size,
             patch_size=patch_size,
-            embed_dim=embed_dim
+            embed_dim=embed_dim,
+            freeze=freeze_encoder
         )
 
         # --- Rig-aware Transformer Decoder ---
@@ -34,7 +35,6 @@ class Rig3R(nn.Module):
             embed_dim=embed_dim,
             num_layers=num_decoder_layers,
             num_heads=num_heads,
-            metadata_dim=metadata_dim,
             mlp_dim=mlp_dim,
             img_size=img_size,
             patch_size=patch_size

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -55,12 +55,11 @@ print(f"Loaded {len(dataset)} sequences from Wayve101")
 model_ckpt = Path.cwd().joinpath(eval_cfg["checkpoint"])
 model = Rig3R(
     img_size=image_size[0],
-    patch_size=8,
-    embed_dim=128,
-    metadata_dim=128,
+    patch_size=16,
+    embed_dim=1024,
     num_decoder_layers=2,
-    num_heads=2,
-    mlp_dim=128*4
+    num_heads=8,
+    mlp_dim=4096
 )
 model.load_state_dict(torch.load(model_ckpt, map_location=device))
 model.to(device)

--- a/scripts/infer_rig_discovery.py
+++ b/scripts/infer_rig_discovery.py
@@ -52,12 +52,11 @@ def main():
     model_ckpt = Path.cwd().joinpath(cfg["checkpoint"])
     model = Rig3R(
         img_size=image_size[0],
-        patch_size=8,
-        embed_dim=128,
-        metadata_dim=128,
+        patch_size=16,
+        embed_dim=1024,
         num_decoder_layers=2,
-        num_heads=2,
-        mlp_dim=128*4
+        num_heads=8,
+        mlp_dim=4096
     )
     
     # We need to handle the fact that we changed the head dimension.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -124,12 +124,11 @@ model = Rig3R(
     encoder_ckpt=pretrain_ckpt_path,
     img_size=img_size[0],
     patch_size=patch_size,
-    embed_dim=128,
-    metadata_dim=128,
+    embed_dim=1024,
     num_decoder_layers=2,
-    num_heads=2,
-    mlp_dim=128*4
-) 
+    num_heads=8,
+    mlp_dim=4096
+)
         
 model.to(device)
 

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -198,12 +198,11 @@ def main():
     # ── Model ────────────────────────────────
     model = Rig3R(
         img_size=image_size[0],
-        patch_size=8,
-        embed_dim=128,
-        metadata_dim=128,
+        patch_size=16,
+        embed_dim=1024,
         num_decoder_layers=2,
-        num_heads=2,
-        mlp_dim=128 * 4,
+        num_heads=8,
+        mlp_dim=4096,
     )
 
     try:

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -23,7 +23,6 @@ decoder = RigAwareTransformerDecoder(
     num_layers=4,
     num_heads=4,
     mlp_dim=C * 4,
-    metadata_dim=None,
     metadata_tokens=2,
     metadata_dropout=0.3,
     attn_dropout=0.0,
@@ -31,8 +30,6 @@ decoder = RigAwareTransformerDecoder(
     patch_size=patch_size
 )
 
-# dummy metadata: (B, M, metadata_dim)
-# meta = torch.randn(B, 2, 32)
 # dummy metadata: dictionary with cam2rig
 metadata = {
     "cam2rig": torch.eye(4).repeat(B, V, 1, 1)  # (B, V, 4, 4) per-view SE(3)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -27,7 +27,11 @@ def test_weights_actually_change():
     loaded_state = loaded_encoder.vit.state_dict()
 
     assert random_state.keys() == loaded_state.keys()
-    unchanged = [k for k in loaded_state if torch.equal(random_state[k], loaded_state[k])]
+    # pos_embed is generated identically in both, so it is expected to match
+    unchanged = [
+        k for k in loaded_state
+        if k != "pos_embed" and torch.equal(random_state[k], loaded_state[k])
+    ]
     assert not unchanged, f"{len(unchanged)} tensors untouched by the load: {unchanged[:5]}"
 
     return loaded_encoder
@@ -44,8 +48,9 @@ def test_every_checkpoint_tensor_is_consumed():
 
     # ViTEncoder loads strict=True, so a successful construction already proves
     # the names and shapes line up exactly. This asserts the count is unchanged.
+    # The +1 is pos_embed, which we generate rather than load.
     encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, **DUST3R_ENCODER)
-    assert len(encoder.vit.state_dict()) == len(encoder_keys)
+    assert len(encoder.vit.state_dict()) == len(encoder_keys) + 1
 
 
 def test_mismatched_dims_raise():
@@ -55,6 +60,31 @@ def test_mismatched_dims_raise():
     except RuntimeError:
         return
     raise AssertionError("embed_dim=128 accepted a 1024-wide checkpoint without raising")
+
+
+def test_positional_encoding_is_real():
+    """The old encoder's 'sinusoidal' embedding was all zeros and never applied.
+
+    Guards both halves: the table must carry signal, and the encoder must actually
+    use it (a position-blind ViT is permutation-equivariant over patches).
+    """
+    encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, **DUST3R_ENCODER)
+    pos_embed = encoder.vit.pos_embed
+
+    patches = (img_size // DUST3R_ENCODER["patch_size"]) ** 2
+    assert pos_embed.shape == (1, patches, DUST3R_ENCODER["embed_dim"])
+    assert pos_embed.abs().sum() > 0, "positional embedding is all zeros"
+    assert not pos_embed.requires_grad, "sine-cosine table should stay frozen"
+
+    # shuffling the table must move the output, or it is not being applied
+    image = torch.randn(1, channels, img_size, img_size)
+    with torch.no_grad():
+        before = encoder(image)["tokens"]
+        encoder.vit.pos_embed = torch.nn.Parameter(
+            pos_embed[:, torch.randperm(patches)], requires_grad=False
+        )
+        after = encoder(image)["tokens"]
+    assert not torch.allclose(before, after, atol=1e-5), "pos_embed is not reaching the blocks"
 
 
 def test_forward_shape_and_freezing():
@@ -71,5 +101,6 @@ if __name__ == "__main__":
     test_weights_actually_change()
     test_every_checkpoint_tensor_is_consumed()
     test_mismatched_dims_raise()
+    test_positional_encoding_is_real()
     test_forward_shape_and_freezing()
     print("encoder checks passed")

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,4 +1,5 @@
 import torch
+import argparse
 
 import sys
 from pathlib import Path
@@ -6,30 +7,69 @@ from pathlib import Path
 root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
-from models.encoder_vit import ViTEncoder
+from models.encoder_vit import ViTEncoder, DUST3R_ENCODER
+
+torch.serialization.add_safe_globals([argparse.Namespace])
 
 ckpt_path = Path.cwd().joinpath("checkpoints/pretrained/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth")
 
-# Parameters
 batch_size = 2
-img_size = 384
-patch_size = 8
+img_size = 128
 channels = 3
 
-# Create dummy input
-dummy_input = torch.randn(batch_size, channels, img_size, img_size)
 
-# Initialize encoder (no checkpoint to keep it simple)
-# encoder = ViTEncoder(checkpoint_path=None, img_size=img_size, patch_size=patch_size)
-encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, patch_size=patch_size)
+def test_weights_actually_change():
+    """The load must move the parameters. Random init vs loaded must differ."""
+    random_encoder = ViTEncoder(checkpoint_path=None, img_size=img_size, **DUST3R_ENCODER)
+    loaded_encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, **DUST3R_ENCODER)
+
+    random_state = random_encoder.vit.state_dict()
+    loaded_state = loaded_encoder.vit.state_dict()
+
+    assert random_state.keys() == loaded_state.keys()
+    unchanged = [k for k in loaded_state if torch.equal(random_state[k], loaded_state[k])]
+    assert not unchanged, f"{len(unchanged)} tensors untouched by the load: {unchanged[:5]}"
+
+    return loaded_encoder
 
 
-# Forward pass
-outputs = encoder(dummy_input)
+def test_every_checkpoint_tensor_is_consumed():
+    """All 292 encoder tensors must land - not a subset, not zero."""
+    checkpoint = torch.load(ckpt_path, map_location="cpu")
+    encoder_keys = [
+        k for k in checkpoint["model"]
+        if k.startswith(("patch_embed.", "enc_blocks.", "enc_norm."))
+    ]
+    assert len(encoder_keys) == 292, f"expected 292 encoder tensors, found {len(encoder_keys)}"
 
-print("Patch tokens shape:", outputs["tokens"].shape)      # (B, N, C)
-print("Feature map shape:", outputs["feature_map"].shape)  # (B, C, H, W)
+    # ViTEncoder loads strict=True, so a successful construction already proves
+    # the names and shapes line up exactly. This asserts the count is unchanged.
+    encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, **DUST3R_ENCODER)
+    assert len(encoder.vit.state_dict()) == len(encoder_keys)
 
-# Check if pos_embed is frozen
-pos_embed_requires_grad = encoder.vit.pos_embed.requires_grad
-print("Positional embedding requires_grad:", pos_embed_requires_grad)
+
+def test_mismatched_dims_raise():
+    """A wrong-width encoder must fail loudly, not silently skip the weights."""
+    try:
+        ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, patch_size=16, embed_dim=128)
+    except RuntimeError:
+        return
+    raise AssertionError("embed_dim=128 accepted a 1024-wide checkpoint without raising")
+
+
+def test_forward_shape_and_freezing():
+    encoder = ViTEncoder(checkpoint_path=ckpt_path, img_size=img_size, **DUST3R_ENCODER)
+    outputs = encoder(torch.randn(batch_size, channels, img_size, img_size))
+
+    patches = (img_size // DUST3R_ENCODER["patch_size"]) ** 2  # 128/16 -> 8x8 = 64
+    assert outputs["tokens"].shape == (batch_size, patches, DUST3R_ENCODER["embed_dim"])
+
+    assert not any(p.requires_grad for p in encoder.vit.parameters()), "encoder should be frozen"
+
+
+if __name__ == "__main__":
+    test_weights_actually_change()
+    test_every_checkpoint_tensor_is_consumed()
+    test_mismatched_dims_raise()
+    test_forward_shape_and_freezing()
+    print("encoder checks passed")

--- a/tests/test_rig3r_forward.py
+++ b/tests/test_rig3r_forward.py
@@ -10,8 +10,7 @@ sys.path.append(str(root_path))
 from models.rig3r import Rig3R
 
 def test_rig3r_forward():
-    B, N, C, H, W = 2, 3, 3, 384, 384  # batch, views, channels, image size
-    # B, N, C, H, W = 1, 1, 3, 128, 128  # batch, views, channels, image size
+    B, N, C, H, W = 2, 3, 3, 128, 128  # batch, views, channels, image size
     dummy_images = torch.randn(B, N, C, H, W)
 
     # Optional: add slight variation per view to mimic multi-view captures
@@ -25,30 +24,18 @@ def test_rig3r_forward():
         "cam2rig": torch.eye(4).repeat(B, N, 1, 1)  # (B, V, 4, 4) per-view SE(3)
     }
 
-    # Initialize model
-    # model = Rig3R(
-    #     encoder_ckpt=None,    # use sinusoidal encoder for test
-    #     img_size=H,
-    #     patch_size=16,
-    #     embed_dim=64,
-    #     metadata_dim=64,
-    #     num_decoder_layers=1,  # small for test
-    #     num_heads=2,
-    #     mlp_dim=128
-    # )
-
     ckpt_path = Path.cwd().joinpath("checkpoints/pretrained/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth")
 
+    # encoder dims are fixed by the DUSt3R ViT-L/16 checkpoint; only the decoder
+    # is free to be small here
     model = Rig3R(
-        encoder_ckpt=ckpt_path,    # use sinusoidal encoder for test
-        # encoder_ckpt=None,    # use sinusoidal encoder for test
+        encoder_ckpt=ckpt_path,
         img_size=H,
-        patch_size=8,
-        embed_dim=384,
-        metadata_dim=384,
-        num_decoder_layers=4,  # small for test
-        num_heads=6,
-        mlp_dim=384*4
+        patch_size=16,
+        embed_dim=1024,
+        num_decoder_layers=1,  # small for test
+        num_heads=8,
+        mlp_dim=1024
     )
 
     # Forward pass
@@ -93,7 +80,6 @@ def test_view_fold_matches_per_view_loop():
        img_size=H,
        patch_size=8,
        embed_dim=64,
-       metadata_dim=64,
        num_decoder_layers=1,
        num_heads=2,
        mlp_dim=128,


### PR DESCRIPTION
## What changed

`ViTEncoder._load_dust3r_weights` printed `Loaded DUSt3R weights (excluding pos_embed)`
and loaded nothing. `strict=False` swallowed a total name mismatch and the return value
carrying `missing_keys`/`unexpected_keys` was discarded. Every run so far trained the
encoder from scratch.

```python
# before
state_dict = torch.load(checkpoint_path, map_location="cpu")   # {"model": ..., "args": ...}
...
state_dict.pop("pos_embed", None)
msg = self.vit.load_state_dict(state_dict, strict=False)       # msg thrown away
print("Loaded DUSt3R weights (excluding pos_embed)")

# after
checkpoint = torch.load(checkpoint_path, map_location="cpu")
state_dict = checkpoint.get("model", checkpoint)               # unwrap
encoder_weights = {
    key.replace("enc_blocks.", "blocks.").replace("enc_norm.", "norm."): value
    for key, value in state_dict.items()
    if key.startswith(("patch_embed.", "enc_blocks.", "enc_norm."))
}
if not encoder_weights:
    raise ValueError(...)
self.vit.load_state_dict(encoder_weights, strict=True)         # raises on any drift
print(f"Loaded {len(encoder_weights)} DUSt3R encoder tensors from {checkpoint_path}")
```

### The backbone was the problem, not the key names

The issue suggested writing a CroCo -> torchvision remap and splitting the fused
`attn.qkv` into `self_attention.in_proj_*`. That work isn't needed — it was the wrong
target module. DUSt3R's encoder is *timm* naming under an `enc_` prefix:

| DUSt3R | timm | torchvision |
|---|---|---|
| `patch_embed.proj.weight` | `patch_embed.proj.weight` | `conv_proj.weight` |
| `enc_blocks.0.attn.qkv.weight` | `blocks.0.attn.qkv.weight` | `...self_attention.in_proj_weight` |
| `enc_norm.weight` | `norm.weight` | `encoder.ln.weight` |

`timm>=1.0.22` was already in `requirements.txt`. Two string replaces get a clean load,
so the encoder is now a `timm.models.VisionTransformer` and torchvision is dropped.

### Encoder is frozen

#34 warned a 1024-wide ViT-L "will not fit a 12 GB card at a useful batch size". That
holds for a *trainable* ViT-L (~5 GiB of AdamW state on top of 303M params), not a frozen
one. Frozen it is a pretrained feature extractor, which is what §3.3 of the paper uses it
as. `freeze=True` is the default, overridable via `Rig3R(freeze_encoder=...)`.

### Two more bugs found in the same file

Neither was in the issue:

- `num_patches = self.vit.dump_patches` — `dump_patches` is `nn.Module`'s debug flag,
  always `False`. So `num_patches == 0` and the "sinusoidal" positional embedding was
  `(1, 1, C)` of **zeros**.
- torchvision's `VisionTransformer` has no `pos_embed` attribute; the real one is
  `vit.encoder.pos_embedding`, which `Encoder.forward` adds unconditionally. Assigning
  `vit.pos_embed` created an unused parameter, so the model was training on a **learned**
  embedding — not the frozen sinusoidal one the code, the `requires_grad=False`, and the
  old test all claimed.

Both are gone with the rewrite. See "Known gap" below for what replaces them.

### Decoder: `meta_proj` double projection

#34 called this correctly. `_collect_metadata_tensors` already projects `cam2rig` to
`embed_dim` via `key_projs["cam2rig"] = nn.Linear(16, embed_dim)`, and
`_prepare_metadata_tokens` then applied `meta_proj = nn.Linear(metadata_dim, embed_dim)`
to the already-projected tensor. It survived only because every call site passed
`metadata_dim == embed_dim`. `meta_proj` and the `metadata_dim` argument are deleted; the
per-key projection does the job.

Also fixed while in there: `_prepare_metadata_tokens` assigned `meta_tokens` in the
`metadata is None` branch but never returned, falling through into
`_collect_metadata_tensors(None, ...)`. Now returns.

### `PointMapHead` ignored its own `patch_size`

Surfaced by moving to `patch_size=16`. The head accepted `patch_size` but hardcoded three
`FusionBlock`s = 8x upsample, correct only at `patch_size=8`:

```
RuntimeError: shape '[6, 16384, 3]' is invalid for input of size 73728
```

Now `log2(patch_size)` blocks in a `ModuleList`, with a power-of-2 guard. Latent bug —
would have hit anyone changing `patch_size` for any reason.

## Files

- `models/encoder_vit.py` — rewritten on timm. Deleted `_build_sinusoidal_pos_embed`,
  `_embed_patches`, `_tokens_to_feature_map`, and the dead `feature_map` output (only
  consumer was a `print` in the old test).
- `models/decoder_transformer.py` — `meta_proj` and `metadata_dim` removed; missing
  `return` fixed.
- `models/heads/pointmap_head.py` — fusion depth derived from `patch_size`.
- `models/rig3r.py` — `metadata_dim` dropped, `freeze_encoder` added, defaults moved to
  `patch_size=16`.
- `scripts/{train,evaluate,visualize,infer_rig_discovery}.py` — `embed_dim=1024`,
  `patch_size=16`, `num_heads=8`, `mlp_dim=4096`.
- `configs/train.yaml`, `configs/train_waymo.yaml` — `patch_size: 16`.
- `tests/test_encoder.py` — rewritten as the regression guard.
- `tests/{test_decoder,test_rig3r_forward}.py` — call sites updated.
- `docs/VISUALIZATION.md` — patch-count example corrected.

Net -175/+176 across 14 files: the encoder shrank from 96 lines to 80 and lost three
methods.

## Measured

RTX 5070, 12 GB, bf16 autocast.

Checkpoint load:

```
top-level keys: ['model', 'args']
encoder tensors: 292
missing: 0   unexpected: 0   matched: 292/292
```

Frozen encoder alone, forward only:

| views | peak memory |
|---|---|
| 32 | 1.19 GiB |
| 64 | 1.25 GiB |
| 128 | 1.36 GiB |

Full `Rig3R` forward + backward, `B=1`, `V=8`, 128x128:

```
params 339M  trainable 36M  frozen 303M
encoder grads: False
peak 1.62 GiB
```

## Test

`tests/test_encoder.py` replaces a script that printed shapes with four asserts. The one
that matters is `test_weights_actually_change` — it builds the encoder twice, once with
the checkpoint and once without, and fails if any tensor is identical:

```python
unchanged = [k for k in loaded_state if torch.equal(random_state[k], loaded_state[k])]
assert not unchanged, f"{len(unchanged)} tensors untouched by the load: {unchanged[:5]}"
```

That is the specific regression #34 describes: a load that reports success and moves
nothing. The old test asserted only that `pos_embed.requires_grad` was `False`, which was
true of a parameter the model never read.

The other four: `test_every_checkpoint_tensor_is_consumed` (292, not a subset),
`test_mismatched_dims_raise` (`embed_dim=128` against a 1024-wide checkpoint must raise,
not silently skip), `test_forward_shape_and_freezing`, and
`test_positional_encoding_is_real`.

That last one guards both halves of the old positional-encoding bug — the table must
carry signal, and the encoder must actually apply it:

```python
assert pos_embed.abs().sum() > 0, "positional embedding is all zeros"
...
encoder.vit.pos_embed = torch.nn.Parameter(pos_embed[:, torch.randperm(patches)], ...)
assert not torch.allclose(before, after, atol=1e-5), "pos_embed is not reaching the blocks"
```

Shuffling the table has to move the output. The original bug was invisible precisely
because nothing asserted either property.

Passing: `test_encoder`, `test_dpt_head`, `test_rig3r_forward`, `test_decoder`,
`test_visualization`, `test_loss`, `test_raymap`. The view-fold equivalence check from
#33 still holds at max abs diff ~5e-7.

### Positional encoding restored (§3.3)

With the two bugs above removed, the encoder had no positional signal at all, leaving it
permutation-equivariant over patches. §3.3 specifies **2D sine-cosine** — not the
checkpoint's RoPE100, and not the learned embedding the old code was accidentally using.

timm already ships this, so the deleted `_build_sinusoidal_pos_embed` is not coming back:

```python
self.vit.pos_embed = nn.Parameter(
    build_sincos2d_pos_embed(self.vit.patch_embed.grid_size, embed_dim).unsqueeze(0),
    requires_grad=False,
)
```

For the record, the old function's *math* was fine — its `div_term` spans 1 → 1e-4 over
256 frequencies, matching the standard formulation. The bugs were `num_patches` (from
`dump_patches`) and the attachment point. Reviving 12 lines that duplicate an installed
dependency would have carried the risk without the benefit.

`pos_embed` stays frozen even when `freeze_encoder=False`, since it is a fixed table. It
is generated, not loaded, so `_load_dust3r_weights` carries it into the state dict before
the strict load — keeping the load strict without pretending the checkpoint supplied it.

## Notes for review

- **Old checkpoints won't load.** `checkpoints/rig3r_epoch*.pt` were saved at
  `embed_dim=128`. Per #34 they are from-scratch runs with a randomly initialised
  encoder, so there is nothing to preserve.
- **Checkpoints are now ~1.3 GB each**, saved every 5 epochs and uploaded as wandb
  artifacts. `scripts/evaluate.py` builds `Rig3R` without `encoder_ckpt` and relies on the
  saved `state_dict` for the encoder, so stripping the frozen weights isn't free — it
  needs `encoder_ckpt` threaded through the eval scripts. Left as-is; worth a follow-up if
  the disk cost bites.
- **The real memory wall is the decoder, not the encoder.** `n_frames: 24` x 5 cameras x
  64 patches = 7680 tokens of joint self-attention at `batch_size: 128`. That was already
  true before this PR and is out of scope here.
- `patch_size` went 8 -> 16, so the raymap/pointmap target resolution drops from 256 to 64
  patches per view at 128x128. Config comment updated to say the value is fixed by the
  ViT-L/16 checkpoint rather than free.
- Follow-ups from a separate paper-alignment pass: #37-#42.
