### PR TITLE
Rig-aware metadata conditioning: additive per-patch embedding, real field dropout, seeded runs

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -34,3 +34,5 @@ device: "cuda"
 
 # Metadata dropout
 metadata_dropout: 0.5
+# Reproducibility: same seed = same init, same shuffle, same metadata dropout
+seed: 0

--- a/configs/train_mini.yaml
+++ b/configs/train_mini.yaml
@@ -26,3 +26,5 @@ device: "cpu"
 
 # Metadata dropout
 metadata_dropout: 0.5
+# Reproducibility: same seed = same init, same shuffle, same metadata dropout
+seed: 0

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -32,5 +32,8 @@ scheduler:
 # Device
 device: "cuda"
 
-# Metadata dropout (for co3d, not used in waymo)
+# Per-field embedding dropout in the decoder, applied to every dataset. The frame
+# index is exempt: sec 3.3 always includes it.
 metadata_dropout: 0.5
+# Reproducibility: same seed = same init, same shuffle, same metadata dropout
+seed: 0

--- a/datasets/co3d.py
+++ b/datasets/co3d.py
@@ -121,6 +121,12 @@ class Co3DDataset(Dataset):
                 else:
                     cam2rigs.append(torch.eye(4))
             metadata['cam2rig'] = torch.stack(cam2rigs)  # (V, 4, 4)
+
+        # CO3D is one camera orbiting one object: no camera identity to convey and no
+        # rig timestamps to normalize, so both of those slices stay empty. The frame
+        # index is always included (sec 3.3) and _maybe_drop_metadata has no branch
+        # for it, so it survives dropout untouched.
+        metadata['frame_index'] = torch.arange(len(selected_files))
         return metadata
     
     def _maybe_drop_metadata(self, metadata):

--- a/datasets/co3d.py
+++ b/datasets/co3d.py
@@ -16,15 +16,13 @@ class Co3DDataset(Dataset):
         subset='train', 
         n_frames=24, 
         image_size=(384, 384),
-        transforms=None,
-        metadata_dropout=0.5
+        transforms=None
     ):
         self.root_dir = root_dir
         self.n_frames = n_frames
         self.transforms = transforms
 
         self.image_size = image_size
-        self.metadata_dropout = metadata_dropout
 
         # 1. Load split list
         self.samples = self._load_split(subset)
@@ -88,8 +86,10 @@ class Co3DDataset(Dataset):
         images = torch.stack(images)  # (N, 3, H, W)
 
         # --- Load frame metadata ---
+        # Field dropout is applied to the embedding inside the decoder (sec 3.4), not
+        # here - a masked value has to read as absent, and a substituted placeholder
+        # reads as a specific wrong value instead.
         metadata = self._load_metadata(seq_path, selected_files)
-        metadata = self._maybe_drop_metadata(metadata)
 
         # --- Load pointcloud GT if exists ---
         pointcloud_file = os.path.join(seq_path, 'pointcloud.ply')
@@ -123,23 +123,6 @@ class Co3DDataset(Dataset):
             metadata['cam2rig'] = torch.stack(cam2rigs)  # (V, 4, 4)
 
         # CO3D is one camera orbiting one object: no camera identity to convey and no
-        # rig timestamps to normalize, so both of those slices stay empty. The frame
-        # index is always included (sec 3.3) and _maybe_drop_metadata has no branch
-        # for it, so it survives dropout untouched.
+        # rig timestamps to normalize, so both of those slices stay empty.
         metadata['frame_index'] = torch.arange(len(selected_files))
-        return metadata
-    
-    def _maybe_drop_metadata(self, metadata):
-        """Apply metadata dropout for robustness"""
-        if self.metadata_dropout > 0 and metadata:
-            for key in metadata.keys():
-                if random.random() < self.metadata_dropout:
-                    # metadata[key] = None
-                    # Replace with placeholder
-                    if key == 'cam2rig':
-                        metadata[key] = torch.eye(4).unsqueeze(0).repeat(self.n_frames, 1, 1)
-                    elif key == 'camera_id':
-                        metadata[key] = torch.full((self.n_frames,), -1, dtype=torch.long)
-                    elif key == 'timestamp':
-                        metadata[key] = torch.zeros(self.n_frames, dtype=torch.float32)
         return metadata

--- a/datasets/waymo.py
+++ b/datasets/waymo.py
@@ -142,9 +142,22 @@ class WaymoDataset(Dataset):
             for camera in self.cameras
         ])
 
+        # images were stacked frame-major, so the camera index cycles fastest
+        n_cameras = len(self.cameras)
+        micros = torch.tensor([int(t) for t in timestamps], dtype=torch.float64)
+
         return {
             "images": images,
-            "metadata": {"cam2rig": cam2rig},  # (n_frames * n_cameras, 4, 4)
+            "metadata": {
+                "cam2rig": cam2rig,  # (n_frames * n_cameras, 4, 4)
+                # ponytail: indices start at 0 rather than being sampled from a
+                # larger range as sec 3.3 does; add that once varying rig sizes
+                # are actually trained on
+                "frame_index": torch.arange(n_frames * n_cameras),
+                "camera_id": torch.arange(n_frames * n_cameras) % n_cameras,
+                # seconds since the sample's first capture, per sec 3.3
+                "timestamp": ((micros - micros[0]) / 1e6).float().repeat_interleave(n_cameras),
+            },
             "intrinsics": intrinsics,  # (n_frames * n_cameras, 4)
             "world_from_rig": world_from_rig,  # (n_frames * n_cameras, 4, 4)
             "pointmap": self._pointmap(segment, timestamps),

--- a/datasets/wayve101.py
+++ b/datasets/wayve101.py
@@ -179,7 +179,17 @@ class Wayve101Dataset(Dataset):
                 if random.random() < self.metadata_dropout:
                     cam2rig[i] = torch.eye(4)
         
-        return {'cam2rig': cam2rig}
+        # images were stacked camera-major here, unlike Waymo, so the camera index
+        # changes slowest. No per-frame timestamps are available, so that slice stays
+        # empty.
+        views = cam2rig.shape[0]
+        frames_per_camera = max(views // len(self.camera_dirs), 1)
+
+        return {
+            'cam2rig': cam2rig,
+            'frame_index': torch.arange(views),
+            'camera_id': torch.arange(views) // frames_per_camera,
+        }
 
     def _load_pointcloud(self, seq_path):
         """

--- a/datasets/wayve101.py
+++ b/datasets/wayve101.py
@@ -10,7 +10,7 @@ from torchvision import transforms
 
 class Wayve101Dataset(Dataset):
     def __init__(self, root_dir, subset='train', n_frames=2, image_size=(384,384),
-                 transforms=None, use_masks=False, metadata_dropout=0.0):
+                 transforms=None, use_masks=False):
         """
         Wayve101 Dataset
 
@@ -21,14 +21,12 @@ class Wayve101Dataset(Dataset):
             image_size (tuple): output image size (H, W).
             transforms: torchvision transforms.
             use_masks (bool): whether to load masks.
-            metadata_dropout (float): dropout for cam2rig metadata.
         """
         self.root_dir = root_dir
         self.n_frames = n_frames
         self.transforms = transforms
         self.image_size = image_size
         self.use_masks = use_masks
-        self.metadata_dropout = metadata_dropout
 
         self.camera_dirs = ['front-forward', 'left-backward', 'left-forward', 'right-backward', 'right-forward']
 
@@ -172,13 +170,11 @@ class Wayve101Dataset(Dataset):
                     cam2rig_list.append(T_cr)
 
         cam2rig = torch.stack(cam2rig_list) # (N, 4, 4)
-        
-        # Apply metadata dropout
-        if self.metadata_dropout > 0:
-            for i in range(cam2rig.shape[0]):
-                if random.random() < self.metadata_dropout:
-                    cam2rig[i] = torch.eye(4)
-        
+
+        # No dropout here on purpose. cam2rig also feeds raymap and pointmap target
+        # construction, so overwriting rows with identity would corrupt ground truth,
+        # not just mask an input. Field dropout lives in the decoder (sec 3.4).
+
         # images were stacked camera-major here, unlike Waymo, so the camera index
         # changes slowest. No per-frame timestamps are available, so that slice stays
         # empty.

--- a/models/decoder_transformer.py
+++ b/models/decoder_transformer.py
@@ -78,6 +78,7 @@ class RigAwareTransformerDecoder(nn.Module):
             num_layers = 8,
             num_heads = 8,
             mlp_dim = 4096,
+            metadata_dropout = 0.5,
             head_hidden = None,
             attn_dropout = 0.0,
             img_size = 384,
@@ -87,6 +88,7 @@ class RigAwareTransformerDecoder(nn.Module):
         self.embed_dim = embed_dim
         self.img_size = img_size
         self.patch_size = patch_size
+        self.metadata_dropout = metadata_dropout
 
         # sec 3.3: the metadata components are concatenated and added to the patch
         # tokens, so each one owns an equal slice of the embedding
@@ -113,6 +115,23 @@ class RigAwareTransformerDecoder(nn.Module):
         # optional final normalization before heads (stable)
         self.final_ln = nn.LayerNorm(embed_dim)
     
+    def _keep_mask(self, B, dims, device):
+        """Per-sample keep/drop mask for one metadata field. (B, 1, ... ) broadcastable
+
+        Sec 3.4 Embedding Dropout: each field is dropped with 50% probability during
+        training so the model learns to infer missing context rather than lean on it.
+        Masking the *embedding* rather than the raw value is what makes a dropped field
+        read as absent - a zeroed camera ID would still encode as camera zero.
+
+        Not scaled by 1/(1-p) the way nn.Dropout is: absent has to look at inference
+        time exactly like it did during training, or dropout itself becomes a train
+        /test mismatch.
+        """
+        if not self.training or self.metadata_dropout <= 0:
+            return torch.ones((1,) * dims, device=device)
+        keep = torch.rand(B, device=device) >= self.metadata_dropout
+        return keep.float().view(B, *([1] * (dims - 1)))
+
     def _metadata_embedding(self, metadata, B, frames, patches_per_frame, device):
         """Per-patch metadata embedding to add to the patch tokens. (B, V * P, C)
 
@@ -132,15 +151,16 @@ class RigAwareTransformerDecoder(nn.Module):
         if frame_index is None:
             frame_index = torch.arange(frames, device=device).expand(B, frames)
 
-        # per-view fields: encoded once per view, then broadcast across its patches
+        # per-view fields: encoded once per view, then broadcast across its patches.
+        # The frame index is never dropped (sec 3.3), the rest are.
         per_view = [sincos1d(frame_index.to(device), self.meta_dim)]
         for key in ("camera_id", "timestamp"):
             value = metadata.get(key)
-            per_view.append(
-                torch.zeros(B, frames, self.meta_dim, device=device)
-                if value is None
-                else sincos1d(value.to(device), self.meta_dim)
-            )
+            if value is None:
+                per_view.append(torch.zeros(B, frames, self.meta_dim, device=device))
+            else:
+                encoded = sincos1d(value.to(device), self.meta_dim)
+                per_view.append(encoded * self._keep_mask(B, encoded.dim(), device))
 
         embedding = torch.cat(per_view, dim=-1).unsqueeze(2)  # (B, V, 1, 3 * meta_dim)
         embedding = embedding.expand(B, frames, patches_per_frame, -1)

--- a/models/decoder_transformer.py
+++ b/models/decoder_transformer.py
@@ -35,15 +35,35 @@ class PreNormTransformerBlock(nn.Module):
         return x
     
 
+def sincos1d(values, dim, max_period=10000.0):
+    """1D sine-cosine embedding of arbitrary values. (..., ) -> (..., dim)
+
+    Takes floats, not just indices, so the same encoding covers the discrete IDs
+    and the normalized timestamp (Rig3R sec 3.3).
+    """
+    assert dim % 2 == 0, f"sincos1d needs an even dim, got {dim}"
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(half, device=values.device) / half
+    )
+    args = values.float().unsqueeze(-1) * freqs
+    return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
+
+
+# Rig3R sec 3.3 metadata fields, in the order their slices are concatenated.
+# The rig raymap patch is per-patch rather than per-view, so it is built separately.
+METADATA_FIELDS = ("frame_index", "camera_id", "timestamp", "rig_raymap")
+
+
 class RigAwareTransformerDecoder(nn.Module):
     """
-        Joint self-attention decoder that attends over concatenated patch tokens from
-        all frames + optional metadata tokens.
+        Joint self-attention decoder over concatenated patch tokens from all frames,
+        with rig-aware metadata added to each patch token.
 
         Inputs:
         - tokens: Tensor (B, V * P, C) where V = frames/views, P = patches per view
         - frames: int, number of frames/views per example (V)
-        - metadata: Optional[Tensor] (B, M, meta_dim) or None
+        - metadata: Optional dict of per-view tensors; see _metadata_embedding
 
         Outputs:
         Dict with:
@@ -58,8 +78,6 @@ class RigAwareTransformerDecoder(nn.Module):
             num_layers = 8,
             num_heads = 8,
             mlp_dim = 4096,
-            metadata_tokens = 1,
-            metadata_dropout = 0.5,
             head_hidden = None,
             attn_dropout = 0.0,
             img_size = 384,
@@ -67,19 +85,15 @@ class RigAwareTransformerDecoder(nn.Module):
     ):
         super().__init__()
         self.embed_dim = embed_dim
-        self.metadata_tokens = metadata_tokens
         self.img_size = img_size
         self.patch_size = patch_size
 
-        # --- Per-key projections ---
-        self.key_projs = nn.ModuleDict({
-            "cam2rig": nn.Linear(16, embed_dim)  # one token per view, a flattened 4x4 SE(3)
-        })
-
-        # if metadata is not provided, we still support learned metadata tokens (learnable)
-        self.learned_meta = nn.Parameter(torch.randn(1, metadata_tokens, embed_dim))
-
-        self.metadata_dropout = nn.Dropout(metadata_dropout)
+        # sec 3.3: the metadata components are concatenated and added to the patch
+        # tokens, so each one owns an equal slice of the embedding
+        assert embed_dim % (2 * len(METADATA_FIELDS)) == 0, (
+            f"embed_dim {embed_dim} must divide into {len(METADATA_FIELDS)} even slices"
+        )
+        self.meta_dim = embed_dim // len(METADATA_FIELDS)
 
         # transformer layers
         self.layers = nn.ModuleList([
@@ -99,58 +113,54 @@ class RigAwareTransformerDecoder(nn.Module):
         # optional final normalization before heads (stable)
         self.final_ln = nn.LayerNorm(embed_dim)
     
-    def _collect_metadata_tensors(self, metadata, device):
-        """
-        Extracts and normalizes metadata dict entries into a list of (B, M, D) tensors.
-        """
-        meta_list = []
-        for key, value in metadata.items():
-            if value is None:
-                continue
-            v = value.to(device)
-            if v.dim() == 4:
-                v = v.flatten(2) # (B, V, 4, 4) -> (B, V, 16), one token per view
-            elif v.dim() == 2:
-                v = v.unsqueeze(1) # (B, D) -> (B, 1, D)
-            elif v.dim() != 3:
-                raise ValueError(f"Unsupported metadata shape for key {key}: {v.shape}")
-            
-            # Project each token using per-key projection
-            proj_layer = self.key_projs[key]
-            if proj_layer is None:
-                raise ValueError(f"No projection defined for metadata key: {key}")
-            # Flatten tokens along sequence for linear, then reshape back
-            B, M, D = v.shape
-            v_flat = v.reshape(B * M, D)
-            v_proj = proj_layer(v_flat).reshape(B, M, self.embed_dim)
-            
-            meta_list.append(v_proj)
-            
-        return meta_list
-    
-    def _prepare_metadata_tokens(self, metadata, batch_size, device):
-        """
-            Returns metadata tokens of shape (B, M, C).
-            - If metadata is provided: each key is projected to embed_dim by its own
-            entry in key_projs, so raw metadata widths need not match embed_dim.
-            - If None: use learned tokens repeated over batch.
-        """
-        if metadata is None:
-            return self.learned_meta.expand(batch_size, -1, -1).to(device)  # (B, M, C)
+    def _metadata_embedding(self, metadata, B, frames, patches_per_frame, device):
+        """Per-patch metadata embedding to add to the patch tokens. (B, V * P, C)
 
-        meta_list = self._collect_metadata_tensors(metadata, device)
+        Each field owns an equal slice of the embedding. A field that is absent or
+        dropped leaves its slice at zero, which is the whole masking mechanism.
 
-        if len(meta_list) == 0:
-            return self.learned_meta.expand(batch_size, -1, -1).to(device)
+        Expected shapes, all optional except the frame index:
+            frame_index: (B, V) long   - sec 3.3 says N is always included, so it is
+                                         synthesised from view order when missing
+            camera_id:   (B, V) long
+            timestamp:   (B, V) float, seconds
+            rig_raymap:  (B, V, P, 6)  - per-patch, not yet wired in
+        """
+        metadata = metadata or {}
 
-        return self.metadata_dropout(torch.cat(meta_list, dim=1))
-    
+        frame_index = metadata.get("frame_index")
+        if frame_index is None:
+            frame_index = torch.arange(frames, device=device).expand(B, frames)
+
+        # per-view fields: encoded once per view, then broadcast across its patches
+        per_view = [sincos1d(frame_index.to(device), self.meta_dim)]
+        for key in ("camera_id", "timestamp"):
+            value = metadata.get(key)
+            per_view.append(
+                torch.zeros(B, frames, self.meta_dim, device=device)
+                if value is None
+                else sincos1d(value.to(device), self.meta_dim)
+            )
+
+        embedding = torch.cat(per_view, dim=-1).unsqueeze(2)  # (B, V, 1, 3 * meta_dim)
+        embedding = embedding.expand(B, frames, patches_per_frame, -1)
+
+        # The rig raymap patch is genuinely per-patch rather than per-view. Wiring it
+        # in is gated on metadata dropout landing first: it is also the rig raymap
+        # head's target, so without masking it hands the answer straight to the head.
+        assert metadata.get("rig_raymap") is None, (
+            "rig raymap metadata needs per-field dropout (#39) before it can be used"
+        )
+        rig_slice = torch.zeros(B, frames, patches_per_frame, self.meta_dim, device=device)
+
+        embedding = torch.cat([embedding, rig_slice], dim=-1)
+        return embedding.reshape(B, frames * patches_per_frame, self.embed_dim)
+
     def forward(self, tokens, frames, metadata=None):
         """
             tokens: (B, V * P, C)
             frames: V (int)
-            metadata: Optional dict of per-key tensors, each projected to embed_dim
-                by key_projs (e.g. cam2rig: (B, V, 4, 4))
+            metadata: Optional dict of per-view tensors; see _metadata_embedding
         """
         B, T_total, C = tokens.shape
         assert C == self.embed_dim, f"tokens embed dim {C} != decoder embed_dim {self.embed_dim}"
@@ -159,19 +169,17 @@ class RigAwareTransformerDecoder(nn.Module):
 
         device = tokens.device
 
-        # prepare metadata tokens (B, M, C)
-        meta_tokens = self._prepare_metadata_tokens(metadata, B, device)  # (B, M, C)
-
-        # concatenate metadata tokens in front of patch tokens: (B, M + T_total, C)
-        seq = torch.cat([meta_tokens, tokens], dim=1)
+        # sec 3.3: metadata is added to every patch token rather than attended to as
+        # separate tokens, so each patch carries its own copy through to the heads
+        seq = tokens + self._metadata_embedding(
+            metadata, B, frames, patches_per_frame, device
+        )
 
         # run joint transformer layers
         for layer in self.layers:
             seq = layer(seq)
 
-        # extract processed patch tokens (skip metadata tokens)
-        proc_patches = seq[:, meta_tokens.shape[1]:, :]  # (B, T_total, C)
-        proc_patches = self.final_ln(proc_patches)
+        proc_patches = self.final_ln(seq)  # (B, T_total, C)
 
         # reshape into (B, V, P, C)
         proc_patches = proc_patches.view(B, frames, patches_per_frame, C)

--- a/models/decoder_transformer.py
+++ b/models/decoder_transformer.py
@@ -97,6 +97,11 @@ class RigAwareTransformerDecoder(nn.Module):
         )
         self.meta_dim = embed_dim // len(METADATA_FIELDS)
 
+        # sec 3.3: the rig raymap patch r_i in R^6 is linearly projected. The discrete
+        # IDs and the timestamp use parameter-free sine-cosine codes, so this is the
+        # only learned part of the metadata embedding.
+        self.rig_proj = nn.Linear(6, self.meta_dim)
+
         # transformer layers
         self.layers = nn.ModuleList([
             PreNormTransformerBlock(embed_dim, num_heads, mlp_dim, dropout=attn_dropout)
@@ -143,7 +148,7 @@ class RigAwareTransformerDecoder(nn.Module):
                                          synthesised from view order when missing
             camera_id:   (B, V) long
             timestamp:   (B, V) float, seconds
-            rig_raymap:  (B, V, P, 6)  - per-patch, not yet wired in
+            rig_raymap:  (B, V, P, 6)  - per-patch, supplied during training only
         """
         metadata = metadata or {}
 
@@ -165,13 +170,16 @@ class RigAwareTransformerDecoder(nn.Module):
         embedding = torch.cat(per_view, dim=-1).unsqueeze(2)  # (B, V, 1, 3 * meta_dim)
         embedding = embedding.expand(B, frames, patches_per_frame, -1)
 
-        # The rig raymap patch is genuinely per-patch rather than per-view. Wiring it
-        # in is gated on metadata dropout landing first: it is also the rig raymap
-        # head's target, so without masking it hands the answer straight to the head.
-        assert metadata.get("rig_raymap") is None, (
-            "rig raymap metadata needs per-field dropout (#39) before it can be used"
-        )
-        rig_slice = torch.zeros(B, frames, patches_per_frame, self.meta_dim, device=device)
+        # The rig raymap patch is per-patch rather than per-view, so it is projected
+        # and masked on its own. It is also the rig raymap head's target, which is why
+        # dropout here is load-bearing rather than mere regularization: without it the
+        # head is handed its own answer on every step.
+        rig_raymap = metadata.get("rig_raymap")
+        if rig_raymap is None:
+            rig_slice = torch.zeros(B, frames, patches_per_frame, self.meta_dim, device=device)
+        else:
+            rig_slice = self.rig_proj(rig_raymap.to(device).float())
+            rig_slice = rig_slice * self._keep_mask(B, rig_slice.dim(), device)
 
         embedding = torch.cat([embedding, rig_slice], dim=-1)
         return embedding.reshape(B, frames * patches_per_frame, self.embed_dim)

--- a/models/rig3r.py
+++ b/models/rig3r.py
@@ -17,6 +17,7 @@ class Rig3R(nn.Module):
         num_decoder_layers=6,
         num_heads=8,
         mlp_dim=2048,
+        metadata_dropout=0.5,
         freeze_encoder=True
     ):
         super().__init__()
@@ -36,6 +37,7 @@ class Rig3R(nn.Module):
             num_layers=num_decoder_layers,
             num_heads=num_heads,
             mlp_dim=mlp_dim,
+            metadata_dropout=metadata_dropout,
             img_size=img_size,
             patch_size=patch_size
         )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -237,14 +237,32 @@ def compute_loss(outputs, batch, device, img_size, patch_size):
 # -----------------------------
 # 6. Batch unpacking
 # -----------------------------
-def unpack_batch(batch, device):
-    """Move a collated sample dict onto the device. Same shape for co3d and waymo."""
+def unpack_batch(batch, device, img_size, patch_size, rig_metadata=False):
+    """Move a collated sample dict onto the device. Same shape for co3d and waymo.
+
+    rig_metadata adds the sec 3.3 rig raymap patch r_i to the metadata. It is the
+    same tensor the rig raymap head is scored against, so it is only ever supplied
+    during training, where the decoder's field dropout withholds it half the time.
+    Validation runs without it on purpose: with dropout off, a model handed r_i would
+    score a near-zero rig loss by copying, which measures nothing. Withholding it
+    makes val/loss report what the paper actually claims - rig structure inferred
+    from images.
+    """
     images = batch["images"].to(device)
 
     metadata = batch["metadata"]
     for key, value in metadata.items():
         if value is not None:
             metadata[key] = value.to(device)
+
+    if rig_metadata and "intrinsics" in batch:
+        metadata["rig_raymap"] = build_raymap_targets(
+            cam2rig=metadata["cam2rig"],
+            intrinsics=batch["intrinsics"].to(device),
+            world_from_rig=batch["world_from_rig"].to(device),
+            image_size=img_size,
+            patch_size=patch_size,
+        )["rig_raymap"]
 
     return images, metadata
 
@@ -256,7 +274,7 @@ run = wandb.init(
     project=train_cfg.get("wandb_project", "open-rig3r"),
     entity=train_cfg.get("wandb_entity"),
     name=train_cfg.get("wandb_run_name"),
-    mode=train_cfg.get("wandb_mode", "offline"),  # "offline" / "disabled" for no network
+    mode=train_cfg.get("wandb_mode", "online"),  # "offline" / "disabled" for no network
     config={**train_cfg, "config_file": args.config, "device": str(device)},
     dir="runs",
 )
@@ -273,7 +291,9 @@ for epoch in range(num_epochs):
     train_bar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Train]", leave=False)
     
     for batch_idx, batch in enumerate(train_bar):
-        images, metadata = unpack_batch(batch, device)
+        images, metadata = unpack_batch(
+            batch, device, img_size, patch_size, rig_metadata=True
+        )
 
         optimizer.zero_grad()
         with autocast(device_type=str(device)):
@@ -303,7 +323,7 @@ for epoch in range(num_epochs):
     val_bar = tqdm(val_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Val]", leave=False)
     with torch.no_grad():
         for batch in val_bar:
-            images, metadata = unpack_batch(batch, device)
+            images, metadata = unpack_batch(batch, device, img_size, patch_size)
 
             with autocast(device_type=str(device)):
                 outputs = model(images, metadata)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,5 @@
 import os
+import random
 import yaml
 import torch
 import argparse
@@ -43,6 +44,14 @@ def load_config(config_path):
 args = parse_args()
 train_cfg = load_config(args.config)
 
+# Without this every run draws a different init and a different shuffle, so two runs
+# of the same config cannot be compared - which is what made the 37a A/B unreadable.
+# DataLoader workers inherit deterministic per-worker seeds from the torch seed.
+seed = train_cfg.get("seed", 0)
+random.seed(seed)
+torch.manual_seed(seed)
+torch.cuda.manual_seed_all(seed)
+
 device = torch.device(train_cfg.get("device", "cuda") if torch.cuda.is_available() else "cpu")
 dataset_type = train_cfg.get("dataset_type", "co3d")
 
@@ -60,8 +69,7 @@ if dataset_type == "co3d":
         subset="train",
         n_frames=train_cfg["n_frames"],
         image_size=img_size,
-        transforms=get_train_transforms(image_size=img_size),
-        metadata_dropout=train_cfg.get("metadata_dropout", 0.5)
+        transforms=get_train_transforms(image_size=img_size)
     )
 
     val_dataset = Co3DDataset(
@@ -69,8 +77,7 @@ if dataset_type == "co3d":
         subset="val",
         n_frames=train_cfg["n_frames"],
         image_size=img_size,
-        transforms=get_val_transforms(image_size=img_size),
-        metadata_dropout=0.0
+        transforms=get_val_transforms(image_size=img_size)
     )
 
 elif dataset_type == "waymo":
@@ -127,7 +134,8 @@ model = Rig3R(
     embed_dim=1024,
     num_decoder_layers=2,
     num_heads=8,
-    mlp_dim=4096
+    mlp_dim=4096,
+    metadata_dropout=train_cfg.get("metadata_dropout", 0.5)
 )
         
 model.to(device)
@@ -248,7 +256,7 @@ run = wandb.init(
     project=train_cfg.get("wandb_project", "open-rig3r"),
     entity=train_cfg.get("wandb_entity"),
     name=train_cfg.get("wandb_run_name"),
-    mode=train_cfg.get("wandb_mode", "online"),  # "offline" / "disabled" for no network
+    mode=train_cfg.get("wandb_mode", "offline"),  # "offline" / "disabled" for no network
     config={**train_cfg, "config_file": args.config, "device": str(device)},
     dir="runs",
 )

--- a/tests/test_co3d.py
+++ b/tests/test_co3d.py
@@ -28,8 +28,7 @@ def smoke_test_co3d():
         subset='train',
         n_frames=4,  # small number for smoke test
         image_size=(128, 128),  # smaller size to save memory
-        transforms=dummy_transforms,
-        metadata_dropout=0.5
+        transforms=dummy_transforms
     )
 
     # --- Wrap in DataLoader ---

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -23,16 +23,16 @@ decoder = RigAwareTransformerDecoder(
     num_layers=4,
     num_heads=4,
     mlp_dim=C * 4,
-    metadata_tokens=2,
-    metadata_dropout=0.3,
     attn_dropout=0.0,
     img_size=img_size,
     patch_size=patch_size
 )
 
-# dummy metadata: dictionary with cam2rig
+# dummy metadata: the per-view fields of sec 3.3
 metadata = {
-    "cam2rig": torch.eye(4).repeat(B, V, 1, 1)  # (B, V, 4, 4) per-view SE(3)
+    "frame_index": torch.arange(V).expand(B, V),
+    "camera_id": torch.arange(V).expand(B, V) % 2,
+    "timestamp": torch.zeros(B, V),
 }
 
 out = decoder(tokens, frames=V, metadata=metadata)

--- a/tests/test_metadata_embedding.py
+++ b/tests/test_metadata_embedding.py
@@ -1,0 +1,116 @@
+# tests/test_metadata_embedding.py
+"""Rig3R sec 3.3 metadata embedding: added to patch tokens, one slice per field."""
+import sys
+from pathlib import Path
+
+import torch
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from models.decoder_transformer import METADATA_FIELDS, RigAwareTransformerDecoder, sincos1d
+
+B, V, P, C = 2, 3, 4, 64
+IMG_SIZE, PATCH_SIZE = 16, 8
+
+
+def build_decoder():
+    return RigAwareTransformerDecoder(
+        embed_dim=C,
+        num_layers=1,
+        num_heads=2,
+        mlp_dim=C * 2,
+        attn_dropout=0.0,
+        img_size=IMG_SIZE,
+        patch_size=PATCH_SIZE,
+    ).eval()
+
+
+def test_frame_index_distinguishes_identical_views():
+    """The decoder is permutation-equivariant without the frame index.
+
+    Feed V identical blocks of patch tokens. Attention alone cannot tell them
+    apart, so any difference between the per-view outputs comes from N.
+    """
+    decoder = build_decoder()
+    one_view = torch.randn(B, P, C)
+    tokens = one_view.repeat(1, V, 1)  # (B, V * P, C), every view identical
+
+    with torch.no_grad():
+        features = decoder(tokens, frames=V)["features"]  # (B, V, P, C)
+
+    spread = max(
+        (features[:, i] - features[:, j]).abs().max().item()
+        for i in range(V)
+        for j in range(i + 1, V)
+    )
+    print(f"max spread across identical views: {spread:.3e}")
+    assert spread > 1e-3, "views are indistinguishable - the frame index is not reaching the tokens"
+    print("Frame index distinguishes identical views test passed!")
+
+
+def test_frame_index_is_synthesised_when_absent():
+    """Sec 3.3: N is always included, so omitting it must not silently drop it."""
+    decoder = build_decoder()
+    tokens = torch.randn(B, V * P, C)
+    explicit = {"frame_index": torch.arange(V).expand(B, V)}
+
+    with torch.no_grad():
+        default = decoder(tokens, frames=V)["features"]
+        supplied = decoder(tokens, frames=V, metadata=explicit)["features"]
+
+    torch.testing.assert_close(default, supplied)
+    print("Frame index defaults to view order test passed!")
+
+
+def test_absent_field_leaves_its_slice_at_zero():
+    """A dropped field must read as absent, not as some particular value."""
+    decoder = build_decoder()
+    meta_dim = decoder.meta_dim
+    assert meta_dim * len(METADATA_FIELDS) == C
+
+    embedding = decoder._metadata_embedding(
+        {"camera_id": torch.zeros(B, V, dtype=torch.long)},
+        B, V, P, torch.device("cpu"),
+    ).view(B, V, P, C)
+
+    # slice order follows METADATA_FIELDS: frame index, camera ID, timestamp, rig raymap
+    for index, field in enumerate(METADATA_FIELDS):
+        chunk = embedding[..., index * meta_dim:(index + 1) * meta_dim]
+        populated = chunk.abs().max() > 0
+        expected = field in ("frame_index", "camera_id")
+        assert populated == expected, f"{field} slice populated={populated}, expected {expected}"
+
+    print("Absent fields leave zeroed slices test passed!")
+
+
+def test_metadata_is_added_not_prepended():
+    """Sec 3.3 adds metadata to the patch tokens; the sequence length must not grow."""
+    decoder = build_decoder()
+    tokens = torch.randn(B, V * P, C)
+
+    with torch.no_grad():
+        features = decoder(tokens, frames=V)["features"]
+
+    assert features.shape == (B, V, P, C), features.shape
+    assert not hasattr(decoder, "learned_meta"), "prepended metadata tokens still present"
+    print("Metadata is added to patch tokens test passed!")
+
+
+def test_sincos1d_encodes_continuous_values():
+    """Timestamps are floats, not indices, so the encoding must separate them."""
+    values = torch.tensor([[0.0, 0.05, 1.0]])
+    encoded = sincos1d(values, 16)
+
+    assert encoded.shape == (1, 3, 16), encoded.shape
+    assert (encoded[0, 0] - encoded[0, 1]).abs().max() > 1e-4, "close timestamps collapsed"
+    torch.testing.assert_close(encoded[0, 0, 8:], torch.ones(8))  # cos(0) = 1
+    print("sincos1d separates continuous values test passed!")
+
+
+if __name__ == "__main__":
+    test_frame_index_distinguishes_identical_views()
+    test_frame_index_is_synthesised_when_absent()
+    test_absent_field_leaves_its_slice_at_zero()
+    test_metadata_is_added_not_prepended()
+    test_sincos1d_encodes_continuous_values()

--- a/tests/test_metadata_embedding.py
+++ b/tests/test_metadata_embedding.py
@@ -27,12 +27,15 @@ def build_decoder(metadata_dropout=0.0):
     ).eval()
 
 
-def full_metadata(B_=B, V_=V):
-    return {
+def full_metadata(B_=B, V_=V, rig=False):
+    metadata = {
         "frame_index": torch.arange(V_).expand(B_, V_),
         "camera_id": torch.arange(V_).expand(B_, V_) % 2,
         "timestamp": torch.linspace(0, 1, V_).expand(B_, V_),
     }
+    if rig:
+        metadata["rig_raymap"] = torch.randn(B_, V_, P, 6)
+    return metadata
 
 
 def slice_of(embedding, field):
@@ -178,6 +181,65 @@ def test_dropped_field_matches_absent_field():
 
     torch.testing.assert_close(dropped, absent)
     print("Dropped reads as absent test passed!")
+
+
+def test_rig_raymap_varies_per_patch():
+    """r_i is a per-patch field; a per-view broadcast would throw its geometry away."""
+    decoder = build_decoder()
+    metadata = full_metadata(rig=True)
+
+    embedding = decoder._metadata_embedding(
+        metadata, B, V, P, torch.device("cpu")
+    ).view(B, V, P, C)
+    rig = slice_of(embedding, "rig_raymap")
+
+    within_patch_spread = (rig - rig.mean(dim=2, keepdim=True)).abs().max()
+    print(f"rig slice spread across patches: {within_patch_spread:.3e}")
+    assert within_patch_spread > 1e-3, "rig raymap collapsed to one value per view"
+
+    # the three per-view fields are constant across patches, by contrast
+    for field in ("frame_index", "camera_id", "timestamp"):
+        chunk = slice_of(embedding, field)
+        torch.testing.assert_close(chunk, chunk[:, :, :1].expand_as(chunk))
+
+    print("Rig raymap varies per patch test passed!")
+
+
+def test_rig_raymap_is_dropped_like_the_other_fields():
+    """The head's own target must be withheld half the time, or it just copies."""
+    torch.manual_seed(0)
+    decoder = build_decoder(metadata_dropout=0.5).train()
+    metadata = full_metadata(B_=64, rig=True)
+
+    dropped = 0
+    trials = 40
+    for _ in range(trials):
+        embedding = decoder._metadata_embedding(
+            metadata, 64, V, P, torch.device("cpu")
+        ).view(64, V, P, C)
+        per_sample = slice_of(embedding, "rig_raymap").abs().amax(dim=(1, 2, 3))
+        dropped += int((per_sample == 0).sum())
+
+    rate = dropped / (trials * 64)
+    print(f"rig_raymap dropped {rate:.3f} of the time")
+    assert 0.4 < rate < 0.6, f"rig raymap dropped at {rate}, expected ~0.5"
+    print("Rig raymap is dropped like the other fields test passed!")
+
+
+def test_rig_raymap_reaches_the_tokens():
+    """A supplied r_i must change the output, or the projection is dead weight."""
+    decoder = build_decoder()
+    tokens = torch.randn(B, V * P, C)
+    metadata = full_metadata(rig=True)
+
+    with torch.no_grad():
+        without = decoder(tokens, frames=V, metadata=full_metadata())["features"]
+        with_rig = decoder(tokens, frames=V, metadata=metadata)["features"]
+
+    delta = (with_rig - without).abs().max()
+    print(f"feature delta from supplying r_i: {delta:.3e}")
+    assert delta > 1e-4, "rig raymap metadata never reached the patch tokens"
+    print("Rig raymap reaches the tokens test passed!")
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_embedding.py
+++ b/tests/test_metadata_embedding.py
@@ -14,16 +14,32 @@ B, V, P, C = 2, 3, 4, 64
 IMG_SIZE, PATCH_SIZE = 16, 8
 
 
-def build_decoder():
+def build_decoder(metadata_dropout=0.0):
     return RigAwareTransformerDecoder(
         embed_dim=C,
         num_layers=1,
         num_heads=2,
         mlp_dim=C * 2,
+        metadata_dropout=metadata_dropout,
         attn_dropout=0.0,
         img_size=IMG_SIZE,
         patch_size=PATCH_SIZE,
     ).eval()
+
+
+def full_metadata(B_=B, V_=V):
+    return {
+        "frame_index": torch.arange(V_).expand(B_, V_),
+        "camera_id": torch.arange(V_).expand(B_, V_) % 2,
+        "timestamp": torch.linspace(0, 1, V_).expand(B_, V_),
+    }
+
+
+def slice_of(embedding, field):
+    """Pull one field's slice out of a (B, V, P, C) metadata embedding."""
+    index = METADATA_FIELDS.index(field)
+    width = C // len(METADATA_FIELDS)
+    return embedding[..., index * width:(index + 1) * width]
 
 
 def test_frame_index_distinguishes_identical_views():
@@ -108,9 +124,68 @@ def test_sincos1d_encodes_continuous_values():
     print("sincos1d separates continuous values test passed!")
 
 
+def test_dropout_is_off_at_eval():
+    """Inference must see every field it was given, every time."""
+    decoder = build_decoder(metadata_dropout=0.5).eval()
+    metadata = full_metadata()
+
+    for _ in range(20):
+        embedding = decoder._metadata_embedding(
+            metadata, B, V, P, torch.device("cpu")
+        ).view(B, V, P, C)
+        assert slice_of(embedding, "camera_id").abs().max() > 0
+        assert slice_of(embedding, "timestamp").abs().max() > 0
+
+    print("Dropout is inactive at eval test passed!")
+
+
+def test_dropout_masks_whole_fields_per_sample():
+    """Sec 3.4: each field is dropped independently, per sample, at ~50%."""
+    torch.manual_seed(0)
+    decoder = build_decoder(metadata_dropout=0.5).train()
+    metadata = full_metadata(B_=64)
+
+    dropped = {"camera_id": 0, "timestamp": 0, "frame_index": 0}
+    trials = 40
+    for _ in range(trials):
+        embedding = decoder._metadata_embedding(
+            metadata, 64, V, P, torch.device("cpu")
+        ).view(64, V, P, C)
+        for field in dropped:
+            # a dropped sample has that field's slice fully zeroed
+            per_sample = slice_of(embedding, field).abs().amax(dim=(1, 2, 3))
+            dropped[field] += int((per_sample == 0).sum())
+
+    total = trials * 64
+    for field in ("camera_id", "timestamp"):
+        rate = dropped[field] / total
+        print(f"{field:12s} dropped {rate:.3f} of the time")
+        assert 0.4 < rate < 0.6, f"{field} dropped at {rate}, expected ~0.5"
+
+    assert dropped["frame_index"] == 0, "the frame index must never be dropped"
+    print("Fields drop independently per sample test passed!")
+
+
+def test_dropped_field_matches_absent_field():
+    """A dropped field must be indistinguishable from one that was never supplied."""
+    decoder = build_decoder(metadata_dropout=1.0).train()  # drop everything droppable
+    device = torch.device("cpu")
+
+    dropped = decoder._metadata_embedding(full_metadata(), B, V, P, device)
+    absent = build_decoder(metadata_dropout=0.0).eval()._metadata_embedding(
+        {"frame_index": torch.arange(V).expand(B, V)}, B, V, P, device
+    )
+
+    torch.testing.assert_close(dropped, absent)
+    print("Dropped reads as absent test passed!")
+
+
 if __name__ == "__main__":
     test_frame_index_distinguishes_identical_views()
     test_frame_index_is_synthesised_when_absent()
     test_absent_field_leaves_its_slice_at_zero()
     test_metadata_is_added_not_prepended()
     test_sincos1d_encodes_continuous_values()
+    test_dropout_is_off_at_eval()
+    test_dropout_masks_whole_fields_per_sample()
+    test_dropped_field_matches_absent_field()

--- a/tests/test_rig3r_forward.py
+++ b/tests/test_rig3r_forward.py
@@ -169,6 +169,43 @@ def test_zero_prediction_no_longer_matches_rig_target():
     print("Zero prediction no longer satisfies the rig target test passed!")
 
 
+def test_rig_raymap_metadata_matches_the_token_grid():
+    """The r_i tensor train.py builds must line up with the model's patch grid.
+
+    build_raymap_targets derives P from image_size / patch_size while the decoder
+    derives it from the token count, so a mismatch between the two only shows up
+    once both run against the same model.
+    """
+    B, N, H, patch = 2, 2, 64, 8
+    torch.manual_seed(0)
+
+    cam2rig = torch.eye(4).repeat(B, N, 1, 1)
+    cam2rig[:, 1, :3, 3] = LEAK_MOUNT
+    intrinsics = torch.tensor([[[32.0, 32.0, 32.0, 32.0]] * N] * B)
+    world_from_rig = torch.eye(4).repeat(B, N, 1, 1)
+
+    rig_raymap = build_raymap_targets(
+        cam2rig, intrinsics, world_from_rig, (H, H), patch
+    )["rig_raymap"]
+
+    model = Rig3R(
+        encoder_ckpt=None, img_size=H, patch_size=patch, embed_dim=64,
+        num_decoder_layers=1, num_heads=2, mlp_dim=128, metadata_dropout=0.0,
+    ).eval()
+
+    images = torch.randn(B, N, 3, H, H)
+    metadata = {"frame_index": torch.arange(N).expand(B, N), "rig_raymap": rig_raymap}
+
+    with torch.no_grad():
+        outputs = model(images, metadata)
+
+    assert rig_raymap.shape == outputs["rig_raymap"].shape, (
+        f"metadata r_i {tuple(rig_raymap.shape)} != prediction "
+        f"{tuple(outputs['rig_raymap'].shape)}"
+    )
+    print(f"r_i and prediction agree at {tuple(rig_raymap.shape)} test passed!")
+
+
 def test_extrinsics_never_reach_rig_head():
     """No route for cam2rig into the head, positionally or by keyword."""
     params = inspect.signature(RigAwareTransformerDecoder.forward).parameters
@@ -209,5 +246,6 @@ if __name__ == "__main__":
     test_rig3r_forward()
     test_view_fold_matches_per_view_loop()
     test_zero_prediction_no_longer_matches_rig_target()
+    test_rig_raymap_metadata_matches_the_token_grid()
     test_extrinsics_never_reach_rig_head()
     test_normalize_touches_directions_only()

--- a/tests/test_waymo.py
+++ b/tests/test_waymo.py
@@ -180,6 +180,39 @@ def test_cam2rig_follows_camera_order(mock_data):
 
 
 @with_mock_dataset
+def test_metadata_fields_follow_view_order(mock_data):
+    """Rig3R sec 3.3 metadata must line up with the frame-major image stacking"""
+    n_frames = 2
+    dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=n_frames)
+    metadata = dataset[0]["metadata"]
+
+    n_cameras = len(CAMERAS)
+    n_views = n_frames * n_cameras
+
+    assert torch.equal(metadata["frame_index"], torch.arange(n_views)), (
+        "frame index must uniquely label every view"
+    )
+    # images are stacked [for t in timestamps: for cam in cameras], so the camera
+    # index cycles fastest and each camera ID reappears once per frame
+    assert torch.equal(metadata["camera_id"], torch.arange(n_views) % n_cameras), (
+        f"camera_id out of order: {metadata['camera_id'].tolist()}"
+    )
+    for camera in range(n_cameras):
+        assert (metadata["camera_id"] == camera).sum() == n_frames
+
+    # timestamps are seconds from the sample's first capture, one value per frame
+    timestamp = metadata["timestamp"]
+    assert timestamp.dtype == torch.float32, timestamp.dtype
+    assert timestamp[:n_cameras].abs().max() == 0, "first frame must sit at t=0"
+    assert torch.equal(timestamp[:n_cameras], timestamp[:n_cameras].flip(0)), (
+        "cameras in one frame share a timestamp"
+    )
+    assert timestamp[n_cameras] > 0, "later frames must have a positive offset"
+    assert timestamp.max() < 60, f"timestamps look like micros, not seconds: {timestamp.max()}"
+    print("✓ test_metadata_fields_follow_view_order passed")
+
+
+@with_mock_dataset
 def test_intrinsics_scaled_to_image_size(mock_data):
     """Intrinsics are exported at native resolution, so the loader must rescale"""
     dataset = WaymoDataset(root_dir=mock_data, split="train", n_frames=1, image_size=(64, 64))
@@ -372,6 +405,7 @@ def run_all_tests():
         test_dataset_getitem,
         test_cam2rig_is_real_calibration,
         test_cam2rig_follows_camera_order,
+        test_metadata_fields_follow_view_order,
         test_intrinsics_scaled_to_image_size,
         test_world_from_rig_is_per_frame,
         test_pointmap_is_loaded_per_view,

--- a/tests/test_wayve101.py
+++ b/tests/test_wayve101.py
@@ -24,8 +24,7 @@ dataset = Wayve101Dataset(
     n_frames=2,
     image_size=img_size,
     transforms=transform,
-    use_masks=True,
-    metadata_dropout=0.0
+    use_masks=True
 )
 
 # --- Grab one sample ---


### PR DESCRIPTION
## What changed

Three things, in dependency order. The second is a hard prerequisite for the third — wiring
the rig raymap in without working dropout would have recreated #38's leak in a worse form.

### 1. Metadata is added to the patch tokens, not prepended as separate tokens

§3.3: *"All components are concatenated and added to the patch tokens."*

```python
# before — models/decoder_transformer.py
meta_tokens = self._prepare_metadata_tokens(metadata, B, device)   # (B, M, C)
seq = torch.cat([meta_tokens, tokens], dim=1)
for layer in self.layers:
    seq = layer(seq)
proc_patches = seq[:, meta_tokens.shape[1]:, :]      # metadata sliced back off

# after
seq = tokens + self._metadata_embedding(metadata, B, frames, patches_per_frame, device)
for layer in self.layers:
    seq = layer(seq)
```

Metadata previously reached patches only indirectly through attention and was discarded
before the heads. Now every patch carries its own copy all the way through.

The four §3.3 fields each own an equal `embed_dim // 4` slice, concatenated to `embed_dim`.
An absent or dropped field leaves its slice at zero — that is the entire masking mechanism,
which is why the old `learned_meta` fallback could be deleted outright.

| field | encoding | shape |
|---|---|---|
| frame index `N` | `sincos1d`, never dropped | `(B, V)` → broadcast over `P` |
| camera ID `c_i` | `sincos1d` | `(B, V)` → broadcast over `P` |
| timestamp `t_i` | `sincos1d`, seconds | `(B, V)` → broadcast over `P` |
| rig raymap `r_i` | `nn.Linear(6, meta_dim)` | `(B, V, P, 6)`, genuinely per-patch |

`sincos1d` takes floats rather than indices, so one encoding covers both the discrete IDs
and the normalized timestamp. `timm` ships only grid-based builders, none of which accept
arbitrary values.

### 2. The frame index was missing entirely, and that was the real bug

§3.3: *"the frame index `N` is always included to uniquely identify each image within the
transformer."*

It did not exist. The decoder ran joint self-attention over all V views with nothing
marking which was which, and attention is permutation-equivariant. Negative control, with
the metadata embedding forced to zero:

```
spread without frame index: 0.000e+00   (test threshold 1e-3)
```

Identical views produced **bit-identical** outputs. Views were indistinguishable to the
model. `N` is now synthesised from view order when a dataset omits it, so the invariant
holds regardless of the data source.

### 3. Embedding dropout moved into the decoder (#39)

§3.4 calls it *"Embedding Dropout"*, and implementing it there rather than in the datasets
collapses every part of #39 at once:

```python
def _keep_mask(self, B, dims, device):
    if not self.training or self.metadata_dropout <= 0:
        return torch.ones((1,) * dims, device=device)
    keep = torch.rand(B, device=device) >= self.metadata_dropout
    return keep.float().view(B, *([1] * (dims - 1)))
```

- **Waymo is covered for free.** `WaymoDataset` took no `metadata_dropout` at all, so the
  primary training set had never masked anything.
- **The collation problem disappears.** Per-sample `None` cannot go through
  `default_collate`, which is why the original author reached for placeholder values. With
  masking at the embedding, no dataset ever emits `None`.
- **The placeholders are deleted.** `_maybe_drop_metadata` is gone from CO3D.
- **The duplicate `nn.Dropout(metadata_dropout)`** on the metadata tokens went with the
  prepend path.

Two details that matter:

**Mask the embedding, not the value.** A zeroed `camera_id` still encodes as *camera zero*
through `sincos1d` — a specific wrong camera, the same class of bug as #39's identity
`cam2rig`. Masking after encoding is what makes dropped read as absent.

**No `1/(1-p)` rescaling**, unlike `nn.Dropout`. Absent at inference has to look exactly
like absent during training, or dropout becomes its own train/test mismatch.

Measured over 2560 samples: `camera_id` 0.496, `timestamp` 0.501, `rig_raymap` 0.508,
`frame_index` 0.000.

### 4. Seeded training runs

`scripts/train.py` seeds `random`, `torch`, and CUDA from a `seed` config key (default 0),
added to all three train configs. Without it no two runs of the same config were
comparable, which is what made the first 37a smoke test unreadable.

## Files

- `models/decoder_transformer.py` — `sincos1d`, `METADATA_FIELDS`, `_keep_mask`,
  `_metadata_embedding`, `rig_proj`. Deleted `learned_meta`, `metadata_tokens`,
  `key_projs`, `_collect_metadata_tensors`, `_prepare_metadata_tokens`, the prepend/slice.
- `models/rig3r.py` — passes `metadata_dropout` through to the decoder.
- `scripts/train.py` — seeding; `unpack_batch` builds `r_i` and gained a `rig_metadata` flag.
- `datasets/waymo.py` — emits `frame_index`, `camera_id`, `timestamp`.
- `datasets/co3d.py` — emits `frame_index`; `_maybe_drop_metadata` deleted.
- `datasets/wayve101.py` — emits `frame_index`, `camera_id`; dropout block removed.
- `configs/*.yaml` — `seed`, and `metadata_dropout` documented as decoder-side.

## View ordering is not the same across datasets

Easy to get backwards, so it is worth stating explicitly:

- **Waymo** stacks frame-major (`for t in timestamps: for cam in cameras`), so the camera
  index cycles fastest → `camera_id = arange(V) % n_cameras`.
- **Wayve101** stacks camera-major, so the camera index changes slowest →
  `camera_id = arange(V) // frames_per_camera`.
- **CO3D** is one camera orbiting one object: no camera identity to convey and no rig
  timestamps, so both slices stay empty.

`test_metadata_fields_follow_view_order` pins the Waymo case.

## Validation deliberately withholds the rig raymap

`r_i` is the same tensor the rig raymap head is scored against. With dropout off at eval, a
model handed `r_i` scores a near-zero rig loss by copying its input to its output — a
number that measures nothing. `unpack_batch` therefore supplies it during training only.

`val/loss` now reports rig structure *inferred from images*, which is the paper's actual
claim and what `scripts/infer_rig_discovery.py` already does by stripping metadata.

**Consequence:** `val/loss` is not comparable to runs from before this branch. It scores a
strictly harder task.

## Also fixed: a dormant target-corruption bug

`datasets/wayve101.py` overwrote `cam2rig` rows with identity **in place**. That tensor also
feeds `build_raymap_targets` and `build_pointmap_target`, so it corrupted *ground truth*,
not just an input — worse than the failure #39 describes. Dormant today because Wayve101 is
not in `train.py`'s dataset switch, but it would have detonated the moment it became a
training set.

## Tests

82 passed. New `tests/test_metadata_embedding.py` (11 tests), plus
`test_metadata_fields_follow_view_order` in `test_waymo.py` and
`test_rig_raymap_metadata_matches_the_token_grid` in `test_rig3r_forward.py`.

The ones that earn their place:

- **`test_frame_index_distinguishes_identical_views`** — feeds V identical blocks of patch
  tokens and requires the outputs to differ. Verified as a real guard: with the embedding
  zeroed, spread is exactly `0.000e+00`.
- **`test_rig_raymap_is_dropped_like_the_other_fields`** — the leak guard. If this ever
  reads ~0, the head is being handed its own target.
- **`test_dropped_field_matches_absent_field`** — dropped must be indistinguishable from
  never-supplied, the property that makes masking correct rather than merely noisy.
- **`test_rig_raymap_varies_per_patch`** — `r_i` must differ across patches within a view
  (spread `2.04`) while the per-view fields stay constant. Catches a broadcast that would
  discard the spatial alignment §3.1 exists for.
- **`test_rig_raymap_metadata_matches_the_token_grid`** — end-to-end.
  `build_raymap_targets` derives `P` from `image_size / patch_size`; the decoder derives it
  from token count. A mismatch only surfaces when both run against one model.

## Measured: seeding works, and here is the noise floor

Two runs, identical config, no code changes between them:

```
step 0   : 80.943031311 vs 80.943031311   diff=0.000e+00
step 1   : 65.114418030 vs 65.114440918   diff=2.289e-05
```

Step 0 is bit-identical, which proves init, shuffle order, worker-side augmentation, and
the metadata dropout draws all match. Divergence enters at step 1 from GPU backward
nondeterminism (atomic accumulation order) and amplifies to ~1.4% relative by end of epoch.

| metric | run A | run B | drift |
|---|---|---|---|
| val/loss | 53.983 | 53.937 | 0.046 (0.09%) |
| last-20 train mean | 4.3224 | 4.3988 | 0.076 (1.8%) |
| epoch train loss | 12.78150 | 12.78128 | 0.0002 |

**Any A/B effect below ~0.05 on `val/loss` is noise.**

I deliberately did not add `torch.use_deterministic_algorithms(True)`: it raises on ops
with no deterministic kernel (likely the DPT head), costs throughput, and buys little
against a floor this low. `cudnn.deterministic` alone would not fix it either — the drift
is atomics, not conv algorithm selection.

## Breaking changes

- **Checkpoints will not load.** `learned_meta` and `key_projs` are gone, `rig_proj` is new.
- **Dataset constructors** no longer accept `metadata_dropout` (`Co3DDataset`,
  `Wayve101Dataset`); the config key now routes to the model.
- **`RigAwareTransformerDecoder`** no longer accepts `metadata_tokens`.
- **`cam2rig` is inert as model input.** It stays in the metadata dict only because
  `compute_loss` builds targets from it. Rig pose now reaches the model exclusively as the
  per-patch `r_i` raymap, which is the representation §3.1 argues for.

## Notes for review

- **Deferred, marked `ponytail:` in `datasets/waymo.py`** — §3.3's *"randomly sampled from a
  larger index range"*. Indices still start at 0. It is the stated mechanism for
  generalizing to unseen frame and camera counts, which is exactly what Table 3 measures,
  so it should land before any WayveScenes101 evaluation.
- `build_raymap_targets` now runs twice per training step, once in `unpack_batch` for the
  input and once in `compute_loss` for the target. A few einsums against a ViT-L forward. I
  left the duplication rather than share one tensor between input and target — that sharing
  is precisely the wiring that caused #38.
- **Not answered by this PR:** whether any of it improves the model. The only honest test is
  an ablation over `metadata_dropout` (1.0 / 0.5 / 0.0) at a fixed seed, which keeps the
  architecture identical across arms so init matches and the 0.05 floor applies. Isolating
  `r_i` specifically needs a per-field `metadata_fields` config knob, not yet added.
