### PR TITLE
Pointmap and raymap losses follow Eq. 3 and Eq. 4

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -12,12 +12,14 @@ n_frames: 24  # consecutive timestamps per sample; views = n_frames * num_camera
 image_size: [128, 128]
 patch_size: 16  # fixed by the DUSt3R ViT-L/16 encoder; also sets the raymap target resolution
 
-# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
-# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+# Loss weights. Every term is scale-free now that the ground truth is divided by the
+# average scene depth (Eq. 3, Eq. 4), so these compare like with like.
 loss:
   w_point: 1.0
   w_pose: 1.0
   w_rig: 1.0
+  alpha: 0.2  # Eq. 3 confidence regularizer. Not given in the paper; DUSt3R's value.
+  beta: 1.0   # Eq. 4 camera-centre weight. Not given in the paper.
 
 # Optimizer configuration
 optimizer:

--- a/configs/train_waymo.yaml
+++ b/configs/train_waymo.yaml
@@ -12,12 +12,14 @@ n_frames: 2  # consecutive timestamps per sample; views = n_frames * num_cameras
 image_size: [128, 128]
 patch_size: 16  # fixed by the DUSt3R ViT-L/16 encoder; also sets the raymap target resolution
 
-# Loss weights. The pointmap term is a metric MSE in metres (tens), the two raymap
-# terms are cosine-based (bounded by 2), so leaving these equal lets depth dominate.
+# Loss weights. Every term is scale-free now that the ground truth is divided by the
+# average scene depth (Eq. 3, Eq. 4), so these compare like with like.
 loss:
   w_point: 1.0
   w_pose: 1.0
   w_rig: 1.0
+  alpha: 0.2  # Eq. 3 confidence regularizer. Not given in the paper; DUSt3R's value.
+  beta: 1.0   # Eq. 4 camera-centre weight. Not given in the paper.
 
 # Optimizer configuration
 optimizer:

--- a/models/heads/pointmap_head.py
+++ b/models/heads/pointmap_head.py
@@ -119,4 +119,10 @@ class PointMapHead(nn.Module):
         confidence = confidence.permute(0, 2, 3, 1)  # (B*V, H, W, 1)
         confidence = confidence.reshape(BV, H * W, 1)  # (B*V, H*W, 1)
 
+        # Eq. 3 weights the error by C and regularizes with -alpha*log(C), so C has to
+        # be positive. Following DUSt3R, keep it above 1 so log(C) >= 0 and the
+        # regularizer can only ever reward confidence, never pay the model to shrink it.
+        # softplus rather than exp: same shape, no overflow on large logits.
+        confidence = 1.0 + F.softplus(confidence)
+
         return pointmap, confidence

--- a/models/losses.py
+++ b/models/losses.py
@@ -72,7 +72,9 @@ class MultiTaskLoss(nn.Module):
         # 2. Pose raymap loss = direction loss + camera center loss
         # ==========================================================
         if 'pose_raymap' in preds and 'pose_raymap' in gts:
-            loss_pose = self._raymap_loss(preds, gts, 'pose_raymap', 'camera_center_pose')
+            loss_pose = self._raymap_loss(
+                preds, gts, 'pose_raymap', 'camera_center_pose', 'pose', loss_dict
+            )
             loss_dict['pose_raymap'] = loss_pose
         else:
             loss_pose = 0.0
@@ -82,7 +84,9 @@ class MultiTaskLoss(nn.Module):
         # 3. Rig raymap loss = direction loss + camera center loss
         # ==========================================================
         if 'rig_raymap' in preds and 'rig_raymap' in gts:
-            loss_rig = self._raymap_loss(preds, gts, 'rig_raymap', 'camera_center_rig')
+            loss_rig = self._raymap_loss(
+                preds, gts, 'rig_raymap', 'camera_center_rig', 'rig', loss_dict
+            )
             loss_dict['rig_raymap'] = loss_rig
         else:
             loss_rig = 0.0
@@ -96,7 +100,7 @@ class MultiTaskLoss(nn.Module):
         loss_dict['total'] = total
         return total, loss_dict
     
-    def _raymap_loss(self, preds, gts, raymap_key, center_key):
+    def _raymap_loss(self, preds, gts, raymap_key, center_key, name, loss_dict):
         """Eq. 4: ||r - r_bar|| over patches, plus beta * ||c - c_bar / z_bar||.
 
         Channels 0:3 of the raymap are the shared camera centre, scored by the centre
@@ -104,13 +108,19 @@ class MultiTaskLoss(nn.Module):
         rather than a cosine is deliberate - for unit vectors ||r - r_bar|| is
         sqrt(2 - 2cos), whose gradient stays linear near the optimum where cosine's
         goes quadratic and fades out.
+
+        The two halves are reported separately in loss_dict: bundled into one number
+        they cannot be compared across a change to either term, because the direction
+        and centre parts move on completely different scales.
         """
         direction = (preds[raymap_key][..., 3:] - gts[raymap_key][..., 3:]).norm(dim=-1)
         loss = self._reduce(direction)
+        loss_dict[f'{name}_dir'] = loss
 
         if center_key in preds and center_key in gts:
-            center = (preds[center_key] - gts[center_key]).norm(dim=-1)
-            loss = loss + self.beta * self._reduce(center)
+            center = self._reduce((preds[center_key] - gts[center_key]).norm(dim=-1))
+            loss_dict[f'{name}_center'] = center
+            loss = loss + self.beta * center
 
         return loss
 

--- a/models/losses.py
+++ b/models/losses.py
@@ -5,13 +5,23 @@ import torch.nn.functional as F
 
 class MultiTaskLoss(nn.Module):
     """
-        Combines pointmap, pose-raymap, and rig-raymap losses with fixed scalar weights.
+        Rig3R Eq. 5: L_total = L_pmap + lambda_p * L_p_rmap + lambda_r * L_r_rmap
+
+        Eq. 3  L_pmap = sum_{i in D_v} C_i * ||X_i - X_bar_i / z_bar|| - alpha log C_i
+        Eq. 4  L_rmap = sum_hw ||r - r_bar|| + beta * ||c - c_bar / z_bar||
+
+        Both equations use an unsquared Euclidean norm, and both expect ground truth
+        already divided by z_bar - see utils.raymap.scene_scale. C is the model's own
+        predicted confidence, not a validity mask.
     """
-    def __init__(self, w_point=1.0, w_pose=1.0, w_rig=1.0, reduction='mean'):
+    def __init__(self, w_point=1.0, w_pose=1.0, w_rig=1.0, alpha=0.2, beta=1.0,
+                 reduction='mean'):
         super().__init__()
         self.w_point = w_point
         self.w_pose = w_pose
         self.w_rig = w_rig
+        self.alpha = alpha  # Eq. 3 confidence regularizer; paper gives no value
+        self.beta = beta    # Eq. 4 camera centre weight; paper gives no value
         self.reduction = reduction
 
     def forward(self, preds, gts):
@@ -37,16 +47,22 @@ class MultiTaskLoss(nn.Module):
         # gts must include: 'pointmap' and 'pointmap_conf'
         # ==========================================================
         if 'pointmap' in preds and 'pointmap' in gts:
-            point_pred = preds['pointmap']
-            point_gt = gts['pointmap']
-            if 'pointmap_conf' in gts:
-                conf = gts['pointmap_conf'] # shape (B, V, P) or (B, V, P, 1)
-                if conf.dim() == 3:
-                    conf = conf.unsqueeze(-1)
-                loss_point = conf * (point_pred - point_gt) ** 2
-                loss_point = self._reduce(loss_point)
+            # Eq. 3 is a norm, not a squared error
+            error = (preds['pointmap'] - gts['pointmap']).norm(dim=-1)  # (B, V, P)
+
+            conf = preds.get('pointmap_conf')
+            if conf is not None:
+                # C is the model's own confidence, so it can downweight what it cannot
+                # see. -alpha*log(C) is what stops it driving C to zero to escape the
+                # loss entirely.
+                conf = conf.squeeze(-1) if conf.dim() == error.dim() + 1 else conf
+                term = conf * error - self.alpha * conf.log()
             else:
-                loss_point = F.mse_loss(point_pred, point_gt, reduction=self.reduction)
+                term = error
+
+            # gts['pointmap_conf'] is the lidar validity fraction: the set D_v Eq. 3
+            # sums over, not a weight. Patches with no return supervise nothing.
+            loss_point = self._reduce_masked(term, gts.get('pointmap_conf'))
             loss_dict['pointmap'] = loss_point
         else:
             loss_point = 0.0
@@ -56,23 +72,7 @@ class MultiTaskLoss(nn.Module):
         # 2. Pose raymap loss = direction loss + camera center loss
         # ==========================================================
         if 'pose_raymap' in preds and 'pose_raymap' in gts:
-            # ---- Direction loss (cosine) ----
-            # channels 0:3 are the shared camera center, scored by its own term below;
-            # including them here would double-count it
-            dir_pred = preds['pose_raymap'][..., 3:]
-            dir_gt = gts['pose_raymap'][..., 3:]
-            loss_dir_pose = 1.0 - F.cosine_similarity(dir_pred, dir_gt, dim=-1)
-            loss_dir_pose = self._reduce(loss_dir_pose)
-
-            # ---- Camera center loss (L2) ----
-            if 'camera_center_pose' in preds and 'camera_center_pose' in gts:
-                cc_pred = preds['camera_center_pose']
-                cc_gt = gts['camera_center_pose']
-                loss_cc_pose = F.mse_loss(cc_pred, cc_gt, reduction=self.reduction)
-            else:
-                loss_cc_pose = 0.0
-
-            loss_pose = loss_dir_pose + loss_cc_pose
+            loss_pose = self._raymap_loss(preds, gts, 'pose_raymap', 'camera_center_pose')
             loss_dict['pose_raymap'] = loss_pose
         else:
             loss_pose = 0.0
@@ -82,22 +82,7 @@ class MultiTaskLoss(nn.Module):
         # 3. Rig raymap loss = direction loss + camera center loss
         # ==========================================================
         if 'rig_raymap' in preds and 'rig_raymap' in gts:
-            # ---- Direction loss ----
-            dir_pred = preds['rig_raymap'][..., 3:]
-            dir_gt = gts['rig_raymap'][..., 3:]
-            loss_dir_rig = 1.0 - F.cosine_similarity(dir_pred, dir_gt, dim=-1)
-            loss_dir_rig = self._reduce(loss_dir_rig)
-
-
-            # ---- Camera center loss ----
-            if 'camera_center_rig' in preds and 'camera_center_rig' in gts:
-                cc_pred = preds['camera_center_rig']
-                cc_gt = gts['camera_center_rig']
-                loss_cc_rig = F.mse_loss(cc_pred, cc_gt, reduction=self.reduction)
-            else:
-                loss_cc_rig = 0.0
-
-            loss_rig = loss_dir_rig + loss_cc_rig
+            loss_rig = self._raymap_loss(preds, gts, 'rig_raymap', 'camera_center_rig')
             loss_dict['rig_raymap'] = loss_rig
         else:
             loss_rig = 0.0
@@ -111,6 +96,36 @@ class MultiTaskLoss(nn.Module):
         loss_dict['total'] = total
         return total, loss_dict
     
+    def _raymap_loss(self, preds, gts, raymap_key, center_key):
+        """Eq. 4: ||r - r_bar|| over patches, plus beta * ||c - c_bar / z_bar||.
+
+        Channels 0:3 of the raymap are the shared camera centre, scored by the centre
+        term; including them in the direction term would count them twice. The norm
+        rather than a cosine is deliberate - for unit vectors ||r - r_bar|| is
+        sqrt(2 - 2cos), whose gradient stays linear near the optimum where cosine's
+        goes quadratic and fades out.
+        """
+        direction = (preds[raymap_key][..., 3:] - gts[raymap_key][..., 3:]).norm(dim=-1)
+        loss = self._reduce(direction)
+
+        if center_key in preds and center_key in gts:
+            center = (preds[center_key] - gts[center_key]).norm(dim=-1)
+            loss = loss + self.beta * self._reduce(center)
+
+        return loss
+
+    def _reduce_masked(self, loss, mask):
+        """Reduce over the valid entries only, so empty patches supervise nothing."""
+        if mask is None:
+            return self._reduce(loss)
+
+        mask = mask.squeeze(-1) if mask.dim() == loss.dim() + 1 else mask
+        valid = mask > 0
+        if not valid.any():
+            return loss.sum() * 0.0  # keeps the graph connected with nothing to learn
+
+        return loss[valid].sum() if self.reduction == 'sum' else loss[valid].mean()
+
     def _reduce(self, loss):
         if self.reduction == 'mean':
             return loss.mean()

--- a/scripts/infer_rig_discovery.py
+++ b/scripts/infer_rig_discovery.py
@@ -11,7 +11,7 @@ root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
 from models.rig3r import Rig3R
-from utils.metrics import chamfer_distance, rig_discovery_accuracy, rig_maa
+from utils.metrics import align_scale, chamfer_distance, rig_discovery_accuracy, rig_maa
 from utils.rig_discovery import recover_pose_closed_form, cluster_rig_poses, reconstruct_pointcloud
 from datasets.wayve101 import Wayve101Dataset
 from torch.utils.data import DataLoader
@@ -137,17 +137,24 @@ def main():
                 # We need to reshape/pass correct format
                 pmaps_list = [pointmaps[b, n] for n in range(N)]
                 pred_pc = reconstruct_pointcloud(pmaps_list, recovered_poses)
-                
+
+                # The model predicts at z-bar normalized scale (Eq. 3 normalizes only
+                # the ground truth), so put it back into metres before any metric that
+                # is expressed in them - Chamfer, and the 0.1 m threshold below.
+                scale = align_scale(pred_pc, gt_pc[b])
+                pred_pc = pred_pc * scale
+
                 # 5. Metrics
-                
+
                 # Chamfer Distance
                 cd = chamfer_distance(pred_pc, gt_pc[b])
                 all_chamfer.append(cd.item())
-                
+
                 # Check if we have valid GT for Rig Metrics
                 if 'cam2rig' in metadata:
                     # Let's construct "pred_rig_keypoints" from our recovered poses (translations)
-                    pred_rig_keypoints = torch.stack([p['t'] for p in recovered_poses])
+                    # Same normalized scale as the pointmap, so the same factor applies.
+                    pred_rig_keypoints = torch.stack([p['t'] for p in recovered_poses]) * scale
 
                     gt_cam2rig = metadata['cam2rig'][b] # (N, ...)
                     

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -24,6 +24,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 from models.rig3r import Rig3R
 from models.losses import MultiTaskLoss
 from utils.amp import needs_grad_scaler, select_amp_dtype
+from utils.metrics import raymap_metrics
 from utils.raymap import build_pointmap_target, build_raymap_targets, scene_scale
 
 # --- Optional: logging ---
@@ -248,6 +249,10 @@ def compute_loss(outputs, batch, device, img_size, patch_size, z_bar):
 
     total, loss_dict = criterion(preds, targets)
 
+    # Geometric metrics, not loss terms: degrees are degrees whatever the objective is,
+    # so these stay comparable across a change to the loss itself.
+    loss_dict.update(raymap_metrics(preds, targets))
+
     # with no matching target MultiTaskLoss returns a plain 0.0 float and the
     # optimizer becomes a no-op - the exact failure this pipeline shipped with.
     # grad_fn is only expected under grad; validation runs inside no_grad.
@@ -357,6 +362,7 @@ for epoch in range(num_epochs):
     # -----------------------------
     model.eval()
     val_loss = 0.0
+    val_totals = {}
     val_bar = tqdm(val_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Val]", leave=False)
     with torch.no_grad():
         for batch in val_bar:
@@ -364,13 +370,20 @@ for epoch in range(num_epochs):
 
             with autocast(device_type=device.type, dtype=amp_dtype):
                 outputs = model(images, metadata)
-            loss, _ = compute_loss(outputs, batch, device, img_size, patch_size, z_bar)
+            loss, val_dict = compute_loss(outputs, batch, device, img_size, patch_size, z_bar)
 
             val_loss += loss.item()
+            for name, value in val_dict.items():
+                val_totals[name] = val_totals.get(name, 0.0) + float(value)
             val_bar.set_postfix({"val_loss": f"{loss.item():.4f}"})
 
-    avg_val_loss = val_loss / len(val_loader)
-    print(f"Epoch [{epoch+1}/{num_epochs}] - Val Loss: {avg_val_loss:.4f}")
+    batches = len(val_loader)
+    avg_val_loss = val_loss / batches
+    val_averages = {name: total / batches for name, total in val_totals.items()}
+    degrees = " ".join(
+        f"{name} {value:.2f}deg" for name, value in val_averages.items() if name.endswith("_deg")
+    )
+    print(f"Epoch [{epoch+1}/{num_epochs}] - Val Loss: {avg_val_loss:.4f}  {degrees}")
 
     wandb.log(
         {
@@ -378,6 +391,7 @@ for epoch in range(num_epochs):
             "train/loss": avg_loss,
             "val/loss": avg_val_loss,
             "lr": scheduler.get_last_lr()[0],
+            **{f"val/{name}": value for name, value in val_averages.items()},
         },
         step=global_step,
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -24,7 +24,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 from models.rig3r import Rig3R
 from models.losses import MultiTaskLoss
 from utils.amp import needs_grad_scaler, select_amp_dtype
-from utils.raymap import build_pointmap_target, build_raymap_targets
+from utils.raymap import build_pointmap_target, build_raymap_targets, scene_scale
 
 # --- Optional: logging ---
 import wandb
@@ -163,13 +163,16 @@ scheduler = CosineAnnealingLR(optimizer,
 # -----------------------------
 # 5. Loss function
 # -----------------------------
-# the pointmap term is a metric MSE in metres and runs an order of magnitude above
-# the two raymap terms, which are cosine-based and bounded by 2 - hence the weights
+# Every term is scale-free now that the ground truth is divided by the average scene
+# depth (Eq. 3, Eq. 4), so these weights finally compare like with like. The paper gives
+# no value for alpha or beta.
 loss_cfg = train_cfg.get("loss", {})
 criterion = MultiTaskLoss(
     w_point=loss_cfg.get("w_point", 1.0),
     w_pose=loss_cfg.get("w_pose", 1.0),
     w_rig=loss_cfg.get("w_rig", 1.0),
+    alpha=loss_cfg.get("alpha", 0.2),
+    beta=loss_cfg.get("beta", 1.0),
 )
 
 
@@ -192,12 +195,16 @@ def downsample_pointmap(pointmap, img_size, patch_size):
     return pooled.permute(0, 2, 3, 1).reshape(B, V, patch_grid * patch_grid, C)
 
 
-def compute_loss(outputs, batch, device, img_size, patch_size):
+def compute_loss(outputs, batch, device, img_size, patch_size, z_bar):
     """Score whatever supervision this batch actually carries.
 
     Waymo currently supplies raymap targets (from calibration + rig poses) but no
     pointcloud; CO3D supplies a pointcloud but no calibration. MultiTaskLoss skips
     any term missing from either side, so each dataset trains on what it has.
+
+    z_bar is (B,) average scene depth. Every target is divided by the same value, so
+    the pointmap and the two camera centres stay on one consistent scale - computing
+    it separately per target would let them disagree.
     """
     preds = dict(outputs)
     targets = {}
@@ -205,18 +212,29 @@ def compute_loss(outputs, batch, device, img_size, patch_size):
     pointcloud = batch["pointcloud"].to(device)
     pointmap = batch.get("pointmap", torch.empty(0)).to(device)
 
+    if pointcloud.numel() > 0 or pointmap.numel() > 0:
+        # the heads predict at image resolution, the targets live on the patch grid
+        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
+        if "pointmap_conf" in preds:
+            preds["pointmap_conf"] = downsample_pointmap(
+                preds["pointmap_conf"], img_size[0], patch_size
+            )
+
     if pointcloud.numel() > 0:
-        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
-        targets["pointmap"] = pointcloud
+        targets["pointmap"] = pointcloud / z_bar.view(-1, 1, 1)
     elif pointmap.numel() > 0:
-        preds["pointmap"] = downsample_pointmap(preds["pointmap"], img_size[0], patch_size)
-        targets["pointmap"], targets["pointmap_conf"] = build_pointmap_target(
+        points, valid = build_pointmap_target(
             pointmap=pointmap,
             cam2rig=batch["metadata"]["cam2rig"].to(device),
             world_from_rig=batch["world_from_rig"].to(device),
             patch_size=patch_size,
             image_size=img_size,
         )
+        # Eq. 3 normalizes only the ground truth, so the model learns to predict at
+        # normalized scale. `valid` is the lidar coverage fraction, used as the mask
+        # D_v rather than as a weight.
+        targets["pointmap"] = points / z_bar.view(-1, 1, 1, 1)
+        targets["pointmap_conf"] = valid
 
     if "intrinsics" in batch:
         targets.update(build_raymap_targets(
@@ -225,6 +243,7 @@ def compute_loss(outputs, batch, device, img_size, patch_size):
             world_from_rig=batch["world_from_rig"].to(device),
             image_size=img_size,
             patch_size=patch_size,
+            z_bar=z_bar,
         ))
 
     total, loss_dict = criterion(preds, targets)
@@ -263,6 +282,13 @@ def unpack_batch(batch, device, img_size, patch_size, rig_metadata=False):
         if value is not None:
             metadata[key] = value.to(device)
 
+    # z_bar comes from the raw ground truth, before any target construction, so the
+    # same value can normalize the pointmap target, both camera centres, and the rig
+    # raymap fed back in as metadata.
+    pointmap = batch.get("pointmap", torch.empty(0)).to(device)
+    source = pointmap if pointmap.numel() > 0 else batch["pointcloud"].to(device)
+    z_bar = scene_scale(source)
+
     if rig_metadata and "intrinsics" in batch:
         metadata["rig_raymap"] = build_raymap_targets(
             cam2rig=metadata["cam2rig"],
@@ -270,9 +296,10 @@ def unpack_batch(batch, device, img_size, patch_size, rig_metadata=False):
             world_from_rig=batch["world_from_rig"].to(device),
             image_size=img_size,
             patch_size=patch_size,
+            z_bar=z_bar,
         )["rig_raymap"]
 
-    return images, metadata
+    return images, metadata, z_bar
 
 
 # -----------------------------
@@ -300,14 +327,14 @@ for epoch in range(num_epochs):
     train_bar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Train]", leave=False)
     
     for batch_idx, batch in enumerate(train_bar):
-        images, metadata = unpack_batch(
+        images, metadata, z_bar = unpack_batch(
             batch, device, img_size, patch_size, rig_metadata=True
         )
 
         optimizer.zero_grad()
         with autocast(device_type=device.type, dtype=amp_dtype):
             outputs = model(images, metadata)
-        loss, loss_dict = compute_loss(outputs, batch, device, img_size, patch_size)
+        loss, loss_dict = compute_loss(outputs, batch, device, img_size, patch_size, z_bar)
 
         scaler.scale(loss).backward()
         scaler.step(optimizer)
@@ -333,11 +360,11 @@ for epoch in range(num_epochs):
     val_bar = tqdm(val_loader, desc=f"Epoch {epoch+1}/{num_epochs} [Val]", leave=False)
     with torch.no_grad():
         for batch in val_bar:
-            images, metadata = unpack_batch(batch, device, img_size, patch_size)
+            images, metadata, z_bar = unpack_batch(batch, device, img_size, patch_size)
 
             with autocast(device_type=device.type, dtype=amp_dtype):
                 outputs = model(images, metadata)
-            loss, _ = compute_loss(outputs, batch, device, img_size, patch_size)
+            loss, _ = compute_loss(outputs, batch, device, img_size, patch_size, z_bar)
 
             val_loss += loss.item()
             val_bar.set_postfix({"val_loss": f"{loss.item():.4f}"})

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -109,8 +109,110 @@ def test_half_precision_predictions_backward():
     print(f"half predictions -> fp32 loss {total.item():.4f}, half grads test passed!")
 
 
+def test_direction_term_is_the_ray_norm_not_cosine():
+    """Eq. 4 uses ||r - r_bar||. For unit vectors that is sqrt(2 - 2cos).
+
+    The distinction matters near the optimum: 1-cos falls off quadratically and its
+    gradient fades, the norm stays linear.
+    """
+    torch.manual_seed(0)
+    directions = torch.nn.functional.normalize(torch.randn(1, 1, 4, 3), dim=-1)
+    perturbed = torch.nn.functional.normalize(directions + 0.3 * torch.randn(1, 1, 4, 3), dim=-1)
+    center = torch.zeros(1, 1, 3)
+
+    preds = {'rig_raymap': raymap(center, perturbed), 'camera_center_rig': center}
+    gts = {'rig_raymap': raymap(center, directions), 'camera_center_rig': center}
+
+    _, loss_dict = MultiTaskLoss(beta=0.0)(preds, gts)
+
+    cosine = torch.nn.functional.cosine_similarity(perturbed, directions, dim=-1)
+    expected = (2 - 2 * cosine).clamp(min=0).sqrt().mean()
+    torch.testing.assert_close(loss_dict['rig_raymap'], expected)
+
+    cosine_loss = (1 - cosine).mean()
+    print(f"ray norm {expected:.4f} vs cosine distance {cosine_loss:.4f} test passed!")
+
+
+def test_matching_directions_score_zero():
+    center = torch.zeros(1, 1, 3)
+    directions = torch.nn.functional.normalize(torch.randn(1, 1, 4, 3), dim=-1)
+    same = {'rig_raymap': raymap(center, directions), 'camera_center_rig': center}
+
+    _, loss_dict = MultiTaskLoss()(dict(same), same)
+    torch.testing.assert_close(loss_dict['rig_raymap'], torch.tensor(0.0))
+    print("A perfect raymap scores zero test passed!")
+
+
+def test_confidence_regularizer_punishes_giving_up():
+    """-alpha*log(C) is what stops the model zeroing its confidence to escape Eq. 3."""
+    torch.manual_seed(0)
+    point_pred = torch.randn(1, 1, 8, 3)
+    gts = {'pointmap': point_pred + 0.5, 'pointmap_conf': torch.ones(1, 1, 8)}
+
+    criterion = MultiTaskLoss(alpha=0.2)
+    losses = {}
+    for name, value in (("giving up", 1.0), ("confident", 8.0)):
+        preds = {'pointmap': point_pred, 'pointmap_conf': torch.full((1, 1, 8, 1), value)}
+        _, loss_dict = criterion(preds, gts)
+        losses[name] = loss_dict['pointmap']
+        print(f"C={value}: pointmap loss {losses[name]:.4f}")
+
+    # with a real error present, high confidence should cost more, not less
+    assert losses["confident"] > losses["giving up"], "confidence is not weighting the error"
+
+    # and without the regularizer nothing stops C collapsing
+    no_reg = MultiTaskLoss(alpha=0.0)
+    tiny = {'pointmap': point_pred, 'pointmap_conf': torch.full((1, 1, 8, 1), 1e-4)}
+    _, unregularized = no_reg(tiny, gts)
+    _, regularized = criterion(tiny, gts)
+    assert regularized['pointmap'] > unregularized['pointmap'], (
+        "alpha must penalise vanishing confidence"
+    )
+    print("Confidence regularizer punishes giving up test passed!")
+
+
+def test_confidence_comes_from_the_prediction():
+    """Eq. 3's C is the model's own output, not the lidar validity mask."""
+    torch.manual_seed(0)
+    point_pred = torch.randn(1, 1, 8, 3)
+    gts = {'pointmap': point_pred + 0.5, 'pointmap_conf': torch.ones(1, 1, 8)}
+    criterion = MultiTaskLoss()
+
+    base = {'pointmap': point_pred, 'pointmap_conf': torch.full((1, 1, 8, 1), 2.0)}
+    moved = {'pointmap': point_pred, 'pointmap_conf': torch.full((1, 1, 8, 1), 4.0)}
+
+    _, a = criterion(base, gts)
+    _, b = criterion(moved, gts)
+    assert not torch.isclose(a['pointmap'], b['pointmap']), (
+        "predicted confidence does not affect the loss - still reading the GT mask"
+    )
+    print("Predicted confidence drives the pointmap term test passed!")
+
+
+def test_invalid_patches_supervise_nothing():
+    """D_v in Eq. 3 is the valid set; patches with no lidar return are excluded."""
+    torch.manual_seed(0)
+    point_pred = torch.randn(1, 1, 4, 3)
+    conf = torch.ones(1, 1, 4, 1)
+
+    gt = point_pred.clone()
+    gt[0, 0, 3] += 100.0  # a wild error, but in a patch with no coverage
+
+    mask = torch.tensor([[[1.0, 1.0, 1.0, 0.0]]])
+    preds = {'pointmap': point_pred, 'pointmap_conf': conf}
+    _, loss_dict = MultiTaskLoss(alpha=0.0)({**preds}, {'pointmap': gt, 'pointmap_conf': mask})
+
+    torch.testing.assert_close(loss_dict['pointmap'], torch.tensor(0.0))
+    print("Masked-out patches contribute nothing test passed!")
+
+
 if __name__ == "__main__":
     test_loss_smoke()
     test_half_precision_predictions_backward()
+    test_direction_term_is_the_ray_norm_not_cosine()
+    test_matching_directions_score_zero()
+    test_confidence_regularizer_punishes_giving_up()
+    test_confidence_comes_from_the_prediction()
+    test_invalid_patches_supervise_nothing()
     test_camera_center_terms_contribute()
     test_direction_term_ignores_the_centre()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,131 @@
+# tests/test_metrics.py
+"""Ray angular error: the one number that survives a change to the loss."""
+import sys
+from pathlib import Path
+
+import torch
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from utils.metrics import ray_angular_error, raymap_metrics
+
+
+def raymap(directions, center=None):
+    """Wrap directions as a (..., 6) raymap, as the heads emit them."""
+    center = torch.zeros_like(directions) if center is None else center
+    return torch.cat([center, directions], dim=-1)
+
+
+def test_identical_rays_score_zero():
+    directions = torch.nn.functional.normalize(torch.randn(1, 2, 8, 3), dim=-1)
+    error = ray_angular_error(raymap(directions), raymap(directions))
+    torch.testing.assert_close(error, torch.tensor(0.0), atol=1e-4, rtol=0)
+    print("Identical rays score zero degrees test passed!")
+
+
+def test_known_angles_are_recovered():
+    """A 90 degree turn must read as 90 degrees, not as a loss-shaped number."""
+    x = torch.tensor([[[[1.0, 0.0, 0.0]]]])
+    y = torch.tensor([[[[0.0, 1.0, 0.0]]]])
+    torch.testing.assert_close(
+        ray_angular_error(raymap(x), raymap(y)), torch.tensor(90.0), atol=1e-3, rtol=0
+    )
+
+    diagonal = torch.tensor([[[[1.0, 1.0, 0.0]]]])
+    torch.testing.assert_close(
+        ray_angular_error(raymap(x), raymap(diagonal)), torch.tensor(45.0), atol=1e-3, rtol=0
+    )
+    print("Known angles recovered exactly test passed!")
+
+
+def test_camera_center_is_ignored():
+    """Centres are metric in some arms and z-bar normalized in others.
+
+    The metric must read only the direction half, or it stops being comparable across
+    exactly the change it exists to measure.
+    """
+    directions = torch.nn.functional.normalize(torch.randn(1, 2, 8, 3), dim=-1)
+    metric = raymap(directions, center=torch.zeros_like(directions))
+    normalized = raymap(directions, center=torch.full_like(directions, 37.0))
+
+    torch.testing.assert_close(
+        ray_angular_error(metric, normalized), torch.tensor(0.0), atol=1e-4, rtol=0
+    )
+    print("Camera centre does not affect the angle test passed!")
+
+
+def test_unnormalized_predictions_still_give_an_angle():
+    """An angle is scale-free; a head that stopped normalizing must not skew it."""
+    directions = torch.nn.functional.normalize(torch.randn(1, 2, 8, 3), dim=-1)
+    scaled = directions * 7.5
+
+    torch.testing.assert_close(
+        ray_angular_error(raymap(scaled), raymap(directions)),
+        torch.tensor(0.0), atol=1e-4, rtol=0,
+    )
+    print("Direction magnitude does not affect the angle test passed!")
+
+
+def test_opposite_rays_are_180_degrees():
+    """Both domain edges must stay finite, not just the near-zero one."""
+    x = torch.tensor([[[[1.0, 0.0, 0.0]]]])
+    error = ray_angular_error(raymap(x), raymap(-x))
+    assert torch.isfinite(error), "angle went NaN at the domain edge"
+    torch.testing.assert_close(error, torch.tensor(180.0), atol=1e-2, rtol=0)
+    print("Opposed rays give 180 degrees, no NaN test passed!")
+
+
+def test_near_zero_angles_stay_precise():
+    """A converged model lives near zero, which is where acos loses its conditioning.
+
+    acos(a.b) reports ~3e-3 degrees of noise on rays identical up to float32 rounding;
+    2*atan2(|a-b|, |a+b|) stays exact there. The metric has to resolve differences
+    smaller than the run-to-run noise floor, so this precision is load-bearing.
+    """
+    directions = torch.nn.functional.normalize(torch.randn(1, 2, 64, 3), dim=-1)
+    rescaled = directions * 7.5  # same rays, different magnitude
+
+    stable = ray_angular_error(raymap(rescaled), raymap(directions))
+
+    cosine = (torch.nn.functional.normalize(rescaled, dim=-1) * directions).sum(-1)
+    naive = torch.rad2deg(torch.acos(cosine.clamp(-1, 1))).mean()
+
+    assert stable < 1e-4, f"atan2 form should be exact here, got {stable}"
+    print(f"near-zero angle: atan2 {stable:.2e} deg vs acos {naive:.2e} deg test passed!")
+
+
+def test_metrics_skip_absent_raymaps():
+    """CO3D supervises no raymaps, so nothing should be reported for it."""
+    directions = torch.nn.functional.normalize(torch.randn(1, 2, 8, 3), dim=-1)
+    preds = {"rig_raymap": raymap(directions), "pose_raymap": raymap(directions)}
+
+    both = raymap_metrics(preds, dict(preds))
+    assert set(both) == {"pose_deg", "rig_deg"}, both
+
+    partial = raymap_metrics(preds, {"rig_raymap": raymap(directions)})
+    assert set(partial) == {"rig_deg"}, partial
+
+    assert raymap_metrics(preds, {}) == {}
+    print("Metrics reported only for supervised raymaps test passed!")
+
+
+def test_matches_a_hand_computed_mean():
+    """The reduction is a mean over every ray, not per view or per batch."""
+    a = torch.tensor([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    b = torch.tensor([[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]])  # 90 and 45 degrees
+
+    error = ray_angular_error(raymap(a), raymap(b))
+    torch.testing.assert_close(error, torch.tensor(67.5), atol=1e-3, rtol=0)
+    print(f"Mean of 90 and 45 is {error:.1f} degrees test passed!")
+
+
+if __name__ == "__main__":
+    test_identical_rays_score_zero()
+    test_known_angles_are_recovered()
+    test_camera_center_is_ignored()
+    test_unnormalized_predictions_still_give_an_angle()
+    test_opposite_rays_are_180_degrees()
+    test_near_zero_angles_stay_precise()
+    test_metrics_skip_absent_raymaps()
+    test_matches_a_hand_computed_mean()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,7 +8,14 @@ import torch
 root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
-from utils.metrics import ray_angular_error, raymap_metrics
+from utils.metrics import (
+    align_scale,
+    chamfer_distance,
+    ray_angular_error,
+    raymap_metrics,
+    rig_discovery_accuracy,
+    rig_maa,
+)
 
 
 def raymap(directions, center=None):
@@ -120,7 +127,51 @@ def test_matches_a_hand_computed_mean():
     print(f"Mean of 90 and 45 is {error:.1f} degrees test passed!")
 
 
+def test_align_scale_recovers_a_known_factor():
+    """The model predicts at z-bar scale; metric evaluation has to undo that."""
+    gt = torch.randn(200, 3) * 12.0
+    for factor in (26.0, 1.0, 0.1):
+        recovered = align_scale(gt / factor, gt)
+        torch.testing.assert_close(recovered, torch.tensor(factor), rtol=1e-4, atol=1e-4)
+    print("align_scale recovers the normalization factor test passed!")
+
+
+def test_align_scale_survives_outliers():
+    """Reconstructed clouds carry outliers, which is why this is a median not a mean."""
+    gt = torch.randn(200, 3) * 12.0
+    pred = gt / 26.0
+    pred[0] = torch.tensor([1e6, 1e6, 1e6])  # one wild point
+
+    recovered = align_scale(pred, gt)
+    assert abs(recovered - 26.0) < 1.0, f"one outlier moved the scale to {recovered}"
+    print(f"align_scale with an outlier: {recovered:.3f} vs 26.0 test passed!")
+
+
+def test_align_scale_handles_empty_clouds():
+    """evaluate.py can hand over an empty prediction; that must not divide by zero."""
+    gt = torch.randn(10, 3)
+    assert align_scale(torch.empty(0, 3), gt) == 1.0
+    assert align_scale(gt, torch.empty(0, 3)) == 1.0
+    print("align_scale is safe on empty clouds test passed!")
+
+
+def test_existing_metrics_are_still_here():
+    """utils/metrics.py predates this branch: evaluate.py and infer_rig_discovery.py
+    import chamfer_distance, rig_discovery_accuracy and rig_maa from it."""
+    a = torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    assert chamfer_distance(a, a) == 0.0
+    assert rig_discovery_accuracy(a, a) == 1.0
+
+    identity = [{"R": torch.eye(3)}, {"R": torch.eye(3)}]
+    torch.testing.assert_close(rig_maa(identity, identity), torch.tensor(0.0), atol=1e-5, rtol=0)
+    print("Pre-existing metrics still present and working test passed!")
+
+
 if __name__ == "__main__":
+    test_align_scale_recovers_a_known_factor()
+    test_align_scale_survives_outliers()
+    test_align_scale_handles_empty_clouds()
+    test_existing_metrics_are_still_here()
     test_identical_rays_score_zero()
     test_known_angles_are_recovered()
     test_camera_center_is_ignored()

--- a/tests/test_scene_scale.py
+++ b/tests/test_scene_scale.py
@@ -1,0 +1,114 @@
+# tests/test_scene_scale.py
+"""Eq. 3 / Eq. 4 scale normalization: one z-bar per sample, shared by every target."""
+import sys
+from pathlib import Path
+
+import torch
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from models.losses import MultiTaskLoss
+from utils.raymap import build_raymap_targets, scene_scale
+
+IMAGE_SIZE = (64, 64)
+PATCH_SIZE = 16
+P = (IMAGE_SIZE[0] // PATCH_SIZE) ** 2
+V = 2
+
+
+def test_scene_scale_is_mean_distance_of_valid_points():
+    points = torch.tensor([[[3.0, 4.0, 0.0], [6.0, 8.0, 0.0]]])  # norms 5 and 10
+    torch.testing.assert_close(scene_scale(points), torch.tensor([7.5]))
+    print("scene_scale averages point distances test passed!")
+
+
+def test_scene_scale_ignores_missing_returns():
+    """Waymo pointmaps are NaN wherever no lidar return landed."""
+    points = torch.tensor([[[3.0, 4.0, 0.0], [float("nan")] * 3, [0.0, 0.0, 0.0]]])
+    torch.testing.assert_close(scene_scale(points), torch.tensor([5.0]))
+    print("scene_scale skips NaN and empty points test passed!")
+
+
+def test_scene_scale_is_per_sample():
+    points = torch.stack([
+        torch.tensor([[3.0, 4.0, 0.0]]),   # 5
+        torch.tensor([[30.0, 40.0, 0.0]]),  # 50
+    ])
+    torch.testing.assert_close(scene_scale(points), torch.tensor([5.0, 50.0]))
+    print("scene_scale is per sample test passed!")
+
+
+def scene(scale=1.0):
+    """A 2-view rig with a mounted second camera, optionally blown up by `scale`."""
+    cam2rig = torch.eye(4).repeat(1, V, 1, 1)
+    cam2rig[0, 1, :3, 3] = torch.tensor([1.5, -0.5, 0.25]) * scale
+    world_from_rig = torch.eye(4).repeat(1, V, 1, 1)
+    world_from_rig[0, 1, :3, 3] = torch.tensor([4.0, 0.0, 0.0]) * scale
+    intrinsics = torch.tensor([[[32.0, 32.0, 32.0, 32.0]] * V])
+    points = torch.tensor([[[[10.0, 1.0, 2.0], [20.0, -3.0, 1.0]]]]) * scale
+    return cam2rig, intrinsics, world_from_rig, points
+
+
+def normalized_targets(scale):
+    cam2rig, intrinsics, world_from_rig, points = scene(scale)
+    z_bar = scene_scale(points)
+    return build_raymap_targets(
+        cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE, z_bar=z_bar
+    ), z_bar
+
+
+def test_targets_are_invariant_to_scene_scale():
+    """The whole point of z-bar: the same geometry ten times bigger trains the same.
+
+    A driving scene and a tabletop differ by orders of magnitude in metres; after
+    normalization they must land on the same numbers.
+    """
+    small, z_small = normalized_targets(1.0)
+    large, z_large = normalized_targets(10.0)
+
+    assert torch.allclose(z_large, z_small * 10), f"{z_small} vs {z_large}"
+
+    for key in ("camera_center_rig", "camera_center_pose", "rig_raymap", "pose_raymap"):
+        torch.testing.assert_close(small[key], large[key], rtol=1e-5, atol=1e-6)
+
+    print(f"z-bar {z_small.item():.3f} -> {z_large.item():.3f}, targets identical test passed!")
+
+
+def test_unnormalized_targets_are_not_invariant():
+    """Negative control: without z-bar the same test would pass vacuously."""
+    cam2rig, intrinsics, world_from_rig, _ = scene(1.0)
+    small = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+    cam2rig, intrinsics, world_from_rig, _ = scene(10.0)
+    large = build_raymap_targets(cam2rig, intrinsics, world_from_rig, IMAGE_SIZE, PATCH_SIZE)
+
+    delta = (large["camera_center_rig"] - small["camera_center_rig"]).abs().max()
+    assert delta > 1.0, "scaling the scene should move unnormalized centres"
+    print(f"unnormalized centres move by {delta:.3f} test passed!")
+
+
+def test_loss_is_invariant_to_scene_scale():
+    """End to end: a model predicting normalized geometry scores the same either way."""
+    torch.manual_seed(0)
+    small, _ = normalized_targets(1.0)
+    large, _ = normalized_targets(10.0)
+
+    preds = {
+        "rig_raymap": small["rig_raymap"] + 0.05 * torch.randn(1, V, P, 6),
+        "camera_center_rig": small["camera_center_rig"] + 0.05 * torch.randn(1, V, 3),
+    }
+    criterion = MultiTaskLoss()
+    loss_small, _ = criterion(preds, small)
+    loss_large, _ = criterion(preds, large)
+
+    torch.testing.assert_close(loss_small, loss_large, rtol=1e-5, atol=1e-6)
+    print(f"loss {loss_small.item():.6f} unchanged across a 10x scene test passed!")
+
+
+if __name__ == "__main__":
+    test_scene_scale_is_mean_distance_of_valid_points()
+    test_scene_scale_ignores_missing_returns()
+    test_scene_scale_is_per_sample()
+    test_targets_are_invariant_to_scene_scale()
+    test_unnormalized_targets_are_not_invariant()
+    test_loss_is_invariant_to_scene_scale()

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,85 +1,44 @@
-# utils/metrics.py
+"""Loss-independent evaluation metrics.
+
+A loss value is only comparable to itself. The moment the objective changes - Eq. 3
+unsquaring the pointmap error, Eq. 4 replacing cosine with a ray norm, z-bar rescaling
+the targets - the number changes units and two runs stop being comparable even at a
+fixed seed. These metrics answer the same geometric question regardless of what the
+model was trained to minimize, so they survive an A/B across a loss change.
+"""
+
 import torch
-from scipy.optimize import linear_sum_assignment
-
-def chamfer_distance(pc1, pc2):
-    """
-    Compute Chamfer Distance between two point clouds.
-
-    Args:
-        pc1: (N1, 3) tensor
-        pc2: (N2, 3) tensor
-    Returns:
-        scalar tensor
-    """
-    if pc1.numel() == 0 or pc2.numel() == 0:
-        return torch.tensor(0.0, device=pc1.device)
-
-    pc1 = pc1.unsqueeze(0)  # (1, N1, 3)
-    pc2 = pc2.unsqueeze(0)  # (1, N2, 3)
-
-    diff = torch.cdist(pc1, pc2)  # (1, N1, N2)
-    dist1 = diff.min(dim=2)[0].mean()
-    dist2 = diff.min(dim=1)[0].mean()
-    return dist1 + dist2
 
 
-def rig_discovery_accuracy(pred_pc, gt_pc):
-    """
-    Evaluate Rig Discovery Accuracy using Hungarian matching.
+def ray_angular_error(pred_raymap, gt_raymap):
+    """Mean angle between predicted and ground-truth ray directions, in degrees.
+
+    Both raymaps carry unit directions, so this needs no scale normalization and means
+    the same thing on either side of a loss change - unlike the camera centre, which is
+    metric in some arms and z-bar normalized in others.
 
     Args:
-        pred_pc: (N, 3) predicted rig keypoints
-        gt_pc: (N, 3) ground truth rig keypoints
-
+        pred_raymap, gt_raymap: (..., 6) centre + direction, or (..., 3) directions
     Returns:
-        fraction of correctly matched points
+        scalar tensor, degrees
     """
-    if pred_pc.numel() == 0 or gt_pc.numel() == 0:
-        return torch.tensor(0.0, device=pred_pc.device)
+    pred = torch.nn.functional.normalize(pred_raymap[..., -3:].float(), dim=-1)
+    gt = torch.nn.functional.normalize(gt_raymap[..., -3:].float(), dim=-1)
 
-    # Compute distance matrix
-    dist_matrix = torch.cdist(pred_pc.unsqueeze(0), gt_pc.unsqueeze(0))[0].cpu().numpy()  # (N_pred, N_gt)
-
-    # Hungarian matching (minimize total distance)
-    row_ind, col_ind = linear_sum_assignment(dist_matrix)
-
-    # Define a threshold for correct match (e.g., 0.1 meters)
-    threshold = 0.1
-    correct = (dist_matrix[row_ind, col_ind] < threshold).sum()
-
-    acc = correct / len(gt_pc)
-    return torch.tensor(acc, device=pred_pc.device)
+    # 2*atan2(|a-b|, |a+b|) rather than acos(a.b): acos is ill-conditioned near cos=1,
+    # where its derivative diverges, and a converged model lives exactly there. The
+    # acos form reports ~0.003 deg of noise on rays that are identical up to float32.
+    angle = 2.0 * torch.atan2(
+        (pred - gt).norm(dim=-1), (pred + gt).norm(dim=-1)
+    )
+    return torch.rad2deg(angle).mean()
 
 
-def rig_maa(pred_poses, gt_poses):
-    """
-    Compute Rig Mean Angular Accuracy (mAA).
-    
-    Args:
-        pred_poses: list of dicts {'R': (3,3)}
-        gt_poses: list of dicts {'R': (3,3)}
-        
-    Returns:
-        scalar tensor (mean angular error in degrees)
-    """
-    if len(pred_poses) != len(gt_poses):
-        return torch.tensor(0.0)
-    
-    angular_errors = []
-    for pred, gt in zip(pred_poses, gt_poses):
-        R_pred = pred['R']
-        R_gt = gt['R']
-        
-        # Relative rotation: R_rel = R_pred @ R_gt.T
-        R_rel = torch.matmul(R_pred, R_gt.T)
-        
-        # Trace of R is 1 + 2cos(theta)
-        trace = torch.trace(R_rel)
-        cos_theta = (trace - 1) / 2.0
-        cos_theta = torch.clamp(cos_theta, -1.0, 1.0)
-        theta = torch.acos(cos_theta) # radians
-        
-        angular_errors.append(torch.rad2deg(theta))
-        
-    return torch.stack(angular_errors).mean()
+def raymap_metrics(preds, targets):
+    """Angular error for whichever raymaps this batch actually supervises. dict"""
+    metrics = {}
+    for name in ("pose", "rig"):
+        key = f"{name}_raymap"
+        if key in preds and key in targets:
+            metrics[f"{name}_deg"] = ray_angular_error(preds[key], targets[key])
+    return metrics

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,13 +1,119 @@
-"""Loss-independent evaluation metrics.
-
-A loss value is only comparable to itself. The moment the objective changes - Eq. 3
-unsquaring the pointmap error, Eq. 4 replacing cosine with a ray norm, z-bar rescaling
-the targets - the number changes units and two runs stop being comparable even at a
-fixed seed. These metrics answer the same geometric question regardless of what the
-model was trained to minimize, so they survive an A/B across a loss change.
-"""
-
+# utils/metrics.py
 import torch
+from scipy.optimize import linear_sum_assignment
+
+def chamfer_distance(pc1, pc2):
+    """
+    Compute Chamfer Distance between two point clouds.
+
+    Args:
+        pc1: (N1, 3) tensor
+        pc2: (N2, 3) tensor
+    Returns:
+        scalar tensor
+    """
+    if pc1.numel() == 0 or pc2.numel() == 0:
+        return torch.tensor(0.0, device=pc1.device)
+
+    pc1 = pc1.unsqueeze(0)  # (1, N1, 3)
+    pc2 = pc2.unsqueeze(0)  # (1, N2, 3)
+
+    diff = torch.cdist(pc1, pc2)  # (1, N1, N2)
+    dist1 = diff.min(dim=2)[0].mean()
+    dist2 = diff.min(dim=1)[0].mean()
+    return dist1 + dist2
+
+
+def rig_discovery_accuracy(pred_pc, gt_pc):
+    """
+    Evaluate Rig Discovery Accuracy using Hungarian matching.
+
+    Args:
+        pred_pc: (N, 3) predicted rig keypoints
+        gt_pc: (N, 3) ground truth rig keypoints
+
+    Returns:
+        fraction of correctly matched points
+    """
+    if pred_pc.numel() == 0 or gt_pc.numel() == 0:
+        return torch.tensor(0.0, device=pred_pc.device)
+
+    # Compute distance matrix
+    dist_matrix = torch.cdist(pred_pc.unsqueeze(0), gt_pc.unsqueeze(0))[0].cpu().numpy()  # (N_pred, N_gt)
+
+    # Hungarian matching (minimize total distance)
+    row_ind, col_ind = linear_sum_assignment(dist_matrix)
+
+    # Define a threshold for correct match (e.g., 0.1 meters)
+    threshold = 0.1
+    correct = (dist_matrix[row_ind, col_ind] < threshold).sum()
+
+    acc = correct / len(gt_pc)
+    return torch.tensor(acc, device=pred_pc.device)
+
+
+def rig_maa(pred_poses, gt_poses):
+    """
+    Compute Rig Mean Angular Accuracy (mAA).
+    
+    Args:
+        pred_poses: list of dicts {'R': (3,3)}
+        gt_poses: list of dicts {'R': (3,3)}
+        
+    Returns:
+        scalar tensor (mean angular error in degrees)
+    """
+    if len(pred_poses) != len(gt_poses):
+        return torch.tensor(0.0)
+    
+    angular_errors = []
+    for pred, gt in zip(pred_poses, gt_poses):
+        R_pred = pred['R']
+        R_gt = gt['R']
+        
+        # Relative rotation: R_rel = R_pred @ R_gt.T
+        R_rel = torch.matmul(R_pred, R_gt.T)
+        
+        # Trace of R is 1 + 2cos(theta)
+        trace = torch.trace(R_rel)
+        cos_theta = (trace - 1) / 2.0
+        cos_theta = torch.clamp(cos_theta, -1.0, 1.0)
+        theta = torch.acos(cos_theta) # radians
+        
+        angular_errors.append(torch.rad2deg(theta))
+        
+    return torch.stack(angular_errors).mean()
+
+
+# ---------------------------------------------------------------------------
+# Loss-independent geometry metrics
+#
+# A loss value is only comparable to itself. The moment the objective changes -
+# Eq. 3 unsquaring the pointmap error, Eq. 4 replacing cosine with a ray norm,
+# z-bar rescaling the targets - the number changes units and two runs stop being
+# comparable even at a fixed seed. These answer the same geometric question
+# regardless of what the model was trained to minimize.
+# ---------------------------------------------------------------------------
+
+
+def align_scale(pred_points, gt_points, eps=1e-8):
+    """Scale factor putting scale-normalized predictions back into metres. scalar tensor
+
+    Eq. 3 divides only the ground truth by z-bar, so a trained model predicts geometry
+    at normalized scale. Any metric in physical units - Chamfer distance, the 0.1 m
+    match threshold in rig_discovery_accuracy - therefore needs one scale factor per
+    sample, recovered from the ground truth. This is the usual scale-invariant
+    evaluation protocol, not a fudge: the model is never asked to learn absolute scale.
+
+    Median of the norms rather than a least-squares fit, because reconstructed point
+    clouds carry outliers that would drag a mean.
+    """
+    if pred_points.numel() == 0 or gt_points.numel() == 0:
+        return torch.tensor(1.0, device=gt_points.device)
+
+    pred_scale = pred_points.reshape(-1, 3).norm(dim=-1).median()
+    gt_scale = gt_points.reshape(-1, 3).norm(dim=-1).median()
+    return gt_scale / pred_scale.clamp(min=eps)
 
 
 def ray_angular_error(pred_raymap, gt_raymap):

--- a/utils/raymap.py
+++ b/utils/raymap.py
@@ -80,7 +80,28 @@ def build_pointmap_target(pointmap, cam2rig, world_from_rig, patch_size, image_s
     return points * (confidence > 0).unsqueeze(-1), confidence
 
 
-def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_size):
+def scene_scale(points, eps=1e-6):
+    """Average scene depth z-bar, per sample. (B,)
+
+    Eq. 3 and Eq. 4 divide the ground truth by z-bar so the model learns geometry at a
+    scale-invariant magnitude - indoor rooms and driving scenes land in the same
+    numerical range. The paper says only "the average scene depth"; following DUSt3R
+    this is the mean distance from the camera to its valid points, so it is a depth in
+    the camera's own frame rather than a distance in some reference view.
+
+    Args:
+        points: (B, ..., 3) ground-truth points in camera frame, NaN where invalid
+    """
+    flat = points.reshape(points.shape[0], -1, 3)
+    distances = flat.norm(dim=-1)
+
+    valid = torch.isfinite(distances) & (distances > 0)
+    total = torch.where(valid, distances, torch.zeros_like(distances)).sum(dim=-1)
+    return (total / valid.sum(dim=-1).clamp(min=1)).clamp(min=eps)
+
+
+def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_size,
+                         z_bar=None):
     """Targets for the rig and pose raymap heads.
 
     Args:
@@ -89,6 +110,9 @@ def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_
         world_from_rig: (B, V, 4, 4) world_from_vehicle at each view's timestamp
         image_size:     (H, W)
         patch_size:     model patch size
+        z_bar:          (B,) average scene depth. Eq. 4 normalizes the camera centre
+                        by it; pass the same value used for the pointmap target or the
+                        two supervisions disagree about scale.
     Returns:
         {"rig_raymap":  (B, V, P, 6), "camera_center_rig":  (B, V, 3),
          "pose_raymap": (B, V, P, 6), "camera_center_pose": (B, V, 3)}
@@ -110,6 +134,13 @@ def build_raymap_targets(cam2rig, intrinsics, world_from_rig, image_size, patch_
     pose_center = transform[..., :3, 3]
     pose_directions = torch.einsum("bvij,bvpj->bvpi", transform[..., :3, :3], directions)
     pose_directions = torch.nn.functional.normalize(pose_directions, dim=-1)
+
+    # Eq. 4 normalizes only the ground-truth centre; the directions are unit vectors
+    # already and carry no scale to remove.
+    if z_bar is not None:
+        scale = z_bar.view(-1, 1, 1)
+        rig_center = rig_center / scale
+        pose_center = pose_center / scale
 
     return {
         "rig_raymap": _raymap(rig_center, rig_directions),


### PR DESCRIPTION
## What Eq. 3 and Eq. 4 actually say

Pulled verbatim, because four separate details were wrong and each one needs its own quote.

> "**Eq. 3**  `L_pmap = Σ_{i∈D_v} C_v^i ‖X_v^i − (1/z̄) X̄_v^i‖ − α log C_v^i`
>
> where `X_v^i` is the predicted 3D point at pixel `i`, `X̄_v^i` is the ground truth,
> `C_v^i` is the **predicted confidence**, `z̄` is the average scene depth used for
> normalization, and `α` is the weight of the regularization term."

> "**Eq. 4**  `L_rmap = Σ_{h,w} ‖r_{v,h,w} − r̄_{v,h,w}‖ + β ‖c_v − (1/z̄) c̄_v‖`
>
> Here, `r_{v,h,w}` is the **predicted unit ray direction** at pixel `(h,w)`... The average
> scene depth `z̄` is used for scale normalization, and `β` weights the center loss term."

Both norms are unsquared Euclidean, and only the *ground truth* is divided by `z̄`.

## The four divergences

### 1. The pointmap error was squared

```python
loss_point = conf * (point_pred - point_gt) ** 2     # Eq. 3 is a norm
```
→ `(preds['pointmap'] - gts['pointmap']).norm(dim=-1)`

### 2. Confidence came from the ground truth, not the model

`gts['pointmap_conf']` is the lidar validity fraction from `utils/raymap.py:72` — a
coverage mask, not the model's belief. The DPT head's own `pointmap_conf` was emitted,
carried through `preds`, and read by nothing.

Now `C` is the prediction, the validity fraction becomes the mask `D_v` that Eq. 3 sums
over, and the missing `−α log C` regulariser is what stops the model driving `C → 0` to
escape the loss. `C` is parameterised as `1 + softplus(x)` so `log C ≥ 0` — softplus rather
than DUSt3R's `exp` to avoid overflow on large logits.

### 3. Cosine distance instead of the ray norm

```python
loss_dir = 1.0 - F.cosine_similarity(dir_pred, dir_gt, dim=-1)
```
→ `(dir_pred - dir_gt).norm(dim=-1)`

For unit vectors `‖r − r̄‖ = √(2 − 2cos)`. Same minimum, different gradient: near the
optimum `1 − cos ≈ θ²/2` and its gradient fades, while the norm stays linear in `θ`. That
is the paper's "more stable", and on the same perturbation the two read `0.4134` vs
`0.0951`.

### 4. No `z̄` scale normalization — the real work

One `z̄` per sample, computed once in `unpack_batch` from the raw ground truth, then
threaded into the pointmap target, both camera centres, and the `r_i` metadata. Computing
it per target would let them disagree about scale, which is the failure this design
prevents.

`scene_scale` needs a definition the paper does not give — "the average scene depth" admits
at least three readings. Following DUSt3R this is the mean distance from the camera to its
valid points, documented as such in the docstring.

`α` and `β` are exposed in `configs/*.yaml`, both labelled "not given in the paper"
(`α = 0.2` is DUSt3R's value; `β = 1.0` is a guess).

## Two corrections to the issue as written

**"The β camera-center term is missing entirely"** — no longer true. #40 landed the pooled
centre MLP, so `camera_center_pose` / `camera_center_rig` exist on both sides and are
scored. β is now only a weight to expose.

**"Switch the raymap direction term to L1 on the raw vectors... `normalize=True` would need
to come off"** — this misreads the paper twice. The text after Eq. 4 defines `r_{v,h,w}` as
the *predicted unit ray direction*, so normalization stays; and `‖·‖` is Euclidean, not L1.
The defect in Eq. 3 is the squaring, not the choice of L2. I raised this disagreement in
the #40 PR and the paper settles it — worth editing the issue.

## The A/B: no measurable difference, and here is why it could not have shown one

`val/loss` is meaningless across this change — the objective was redefined, so the units
changed. That needed a loss-independent metric, hence commit two: mean ray angular error in
degrees, unit vectors on both sides, no rescaling, identical code.

Same seed, `metadata_dropout: 0.5`, one epoch, `main` vs this branch. #41 adds no
parameters, so initialization and data order are bit-identical across arms — the first
genuinely clean A/B in this repo.

| | `val/pose_deg` | `val/rig_deg` |
|---|---|---|
| PRE | 45.798 | 46.362 |
| POST | 46.721 | 47.399 |
| POST repeat | 45.698 | 46.222 |
| noise floor `\|POST−repeat\|` | 1.023 | 1.177 |
| effect `POST−PRE` | +0.923 | +1.037 |

The effect is **0.9x the noise floor**, and the sign is not stable: the repeat run lands
closer to PRE than to POST. That is noise.

### The finding that matters more

Baselines computed from the real Waymo geometry:

```
per-view constant ray  (predict each view's mean direction)  15.83 deg
model, both arms                                             ~46    deg
single global constant ray                                   57.8  deg
random unit vectors                                          90    deg
```

At ~46° the model sits between "one constant ray for everything" and "one constant ray per
view" — **3x worse than a trivial per-view constant**. After 247 steps at batch 4, against
the paper's 250k steps at batch 128, the direction heads have learned essentially nothing.
No loss formulation could have separated here.

So this PR is justified on fidelity, not performance: the losses diverged from Eq. 3 and
Eq. 4, and now they do not. The A/B was a do-no-harm check and it passed.

## Commit 3: a file I broke and restored

`55d5f5e` overwrote `utils/metrics.py` instead of extending it, dropping
`chamfer_distance`, `rig_discovery_accuracy` and `rig_maa`. Both `scripts/evaluate.py` and
`scripts/infer_rig_discovery.py` import those, so both died at startup with `ImportError`.
The suite never caught it because nothing imports those scripts.

Restored verbatim, with the new metrics appended below. `test_existing_metrics_are_still_here`
exercises all three so the next overwrite fails the suite rather than an eval run.

## Predictions are no longer metric

Since only the ground truth is divided by `z̄`, the model learns to emit at normalized
scale. Anything measuring in metres has to undo that:

```python
scale = align_scale(pred_pc, gt_pc[b])
pred_pc = pred_pc * scale
```

`scripts/infer_rig_discovery.py` needed it twice — Chamfer distance is in metres, and
`rig_discovery_accuracy` hard-codes a `0.1 m` match threshold. Without the rescale
predictions arrive ~26x too small, which would have *inflated* rig accuracy, every keypoint
falling inside the threshold by construction. `align_scale` takes the median of point norms
rather than a least-squares fit, since reconstructed clouds carry outliers.

This is the standard scale-invariant evaluation protocol, not a workaround: the model is
never asked to learn absolute scale.

**`scripts/visualize.py` is not updated** — point clouds now render in scene-relative units.
Cosmetic, but it will look wrong next to a metric ground truth.

## Files

- `models/losses.py` — Eq. 3 and Eq. 4; `α`, `β`; direction and centre reported separately.
- `models/heads/pointmap_head.py` — `C = 1 + softplus(x)`.
- `utils/raymap.py` — `scene_scale`; `z_bar` threaded into the raymap targets.
- `utils/metrics.py` — restored, plus `ray_angular_error`, `raymap_metrics`, `align_scale`.
- `scripts/train.py` — `z̄` computed once per batch; angular error logged at val.
- `scripts/infer_rig_discovery.py` — rescale before metric-unit metrics.
- `configs/*.yaml` — `α`, `β`; stale "metric MSE in metres" comments removed.

## Tests

116 passed. New: `tests/test_scene_scale.py` (6), `tests/test_metrics.py` (12), and 5 more
in `tests/test_loss.py`.

- **`test_targets_are_invariant_to_scene_scale`** — the same geometry 10x larger produces
  identical targets and an identical loss. Paired with
  `test_unnormalized_targets_are_not_invariant`, without which the first test would pass
  vacuously.
- **`test_confidence_regularizer_punishes_giving_up`** — driving `C → 0` must raise the
  loss. Checked in both directions, with and without `α`.
- **`test_invalid_patches_supervise_nothing`** — a 100-unit error in an uncovered patch
  contributes exactly zero, pinning `D_v`.
- **`test_near_zero_angles_stay_precise`** — the metric uses `2·atan2(|a−b|, |a+b|)`, not
  `acos(a·b)`. `acos` is ill-conditioned near `cos=1`, exactly where a converged model
  lives, and reports `3.87e-03` degrees of noise on rays identical up to float32 against
  `2.58e-06` for the atan2 form. The metric has to resolve differences below a ~1 degree
  noise floor, so this is load-bearing.
- **`test_align_scale_survives_outliers`** — a `1e6` point still recovers 25.9 against a
  true 26.0.

## Breaking changes

- **Checkpoints will not load.** The DPT head's confidence activation changed.
- **Loss values are not comparable to any earlier run**, by construction.
- **`val/loss` is not comparable to pre-#41 runs either** — use `val/pose_deg` and
  `val/rig_deg`.

## Notes for review

- **Normalizing the rig centre by scene depth is odd, and the paper does it anyway.** `c̄_v`
  for the rig raymap is a static mount offset, independent of how far away the scene is;
  dividing it by scene depth couples a fixed extrinsic to scene content. Eq. 4 is written
  once and applied to both heads, so following the paper means doing it. Flagging rather
  than quietly deviating.
- **Every loss weight needs retuning.** All three terms are scale-free now, so `w_point: 1.0`
  no longer means what it did.
- **The direction/centre split keys are per-arm only.** `pose_dir` in one arm is a cosine
  distance and a ray norm in another. Only `*_deg` compares across a loss change.
- **Found while writing this up: #47.** `scripts/evaluate.py` reads `outputs['pointcloud_pred']`,
  a key the model has never emitted, so it has been reporting `Chamfer 0.000000` for every
  run it has ever done. Predates this branch and is not made worse by it, but its numbers
  are fiction until fixed.
- **A/B reproducibility:** pre arm is `f7ec077` + the metric commit; post arm is `55d5f5e`.
  Configs were kept in `personals/` (gitignored) rather than committed as repo config.
