### PR TITLE
Make Wayve101 evaluation produce a real number

### DIFF
--- a/configs/evaluate.yaml
+++ b/configs/evaluate.yaml
@@ -1,2 +1,2 @@
 checkpoint: "checkpoints/rig3r_epoch50.pt"
-data: "data/wayve_scenes_101/scene_001"
+data: "data/wayve_scenes_101"

--- a/configs/evaluate_mini.yaml
+++ b/configs/evaluate_mini.yaml
@@ -1,2 +1,2 @@
 checkpoint: "checkpoints/rig3r_epoch5.pt"
-data: "data/wayve_scenes_101/scene_001"
+data: "data/wayve_scenes_101"

--- a/datasets/wayve101.py
+++ b/datasets/wayve101.py
@@ -15,7 +15,10 @@ class Wayve101Dataset(Dataset):
         Wayve101 Dataset
 
         Args:
-            root_dir (str): path to WayveScenes101 dataset root.
+            root_dir (str): path to the WayveScenes101 root - the directory that
+                *contains* the scene directories, not a single scene. Each
+                subdirectory is one sequence (non-directories such as the
+                downloaded .zip archives are ignored).
             subset (str): train/val/test split (optional, placeholder).
             n_frames (int): number of frames to sample per camera.
             image_size (tuple): output image size (H, W).
@@ -31,7 +34,8 @@ class Wayve101Dataset(Dataset):
         self.camera_dirs = ['front-forward', 'left-backward', 'left-forward', 'right-backward', 'right-forward']
 
         # 1. Load sequences
-        self.samples = [os.path.join(root_dir, seq) for seq in os.listdir(root_dir)
+        # sorted so seq_idx means the same scene across runs and machines
+        self.samples = [os.path.join(root_dir, seq) for seq in sorted(os.listdir(root_dir))
                         if os.path.isdir(os.path.join(root_dir, seq))]
 
     def __len__(self):
@@ -201,39 +205,36 @@ class Wayve101Dataset(Dataset):
         def read_bin_point3D(file_path):
             points = []
             with open(file_path, 'rb') as f:
-                header = f.read(8)
-                if len(header) < 8:
+                # The file is a uint64 count followed immediately by the records -
+                # there is no separate header to skip first.
+                count = f.read(8)
+                if len(count) < 8:
                     return torch.empty(0, 3)
-                # header
-                num_points = struct.unpack('<Q', f.read(8))[0]
+                num_points = struct.unpack('<Q', count)[0]
+
                 for _ in range(num_points):
                     data = f.read(8 + 24 + 3 + 8 + 8)  # point_id + xyz + rgb + error + track_len
                     if len(data) < 51:  # 8+24+3+8+8=51
                         break  # EOF reached unexpectedly
-                    
-                    point_id = struct.unpack('<Q', data[:8])[0]
+
                     xyz = struct.unpack('<ddd', data[8:32])
                     track_len = struct.unpack('<Q', data[43:51])[0]
 
-                    # Read & discard track data in small chunks to avoid invalid seek
-                    bytes_to_skip = track_len * 16
-                    chunk_size = 1024 * 1024  # 1 MB chunks
-                    while bytes_to_skip > 0:
-                        skip = min(bytes_to_skip, chunk_size)
-                        read_bytes = f.read(skip)
-                        if len(read_bytes) < skip:
-                            break
-                        bytes_to_skip -= len(read_bytes)
-
+                    # One track element is (uint32 image_id, uint32 point2D_idx) = 8 bytes.
+                    # Reading 16 here walks off the record boundary and the next
+                    # track_len decodes as garbage, ending the loop after one point.
+                    f.seek(track_len * 8, os.SEEK_CUR)
 
                     points.append(xyz)
+
+            if not points:
+                return torch.empty(0, 3)
             return torch.tensor(points, dtype=torch.float32)
         
         return read_bin_point3D(bin_file)
 
     def __getitem__(self, idx):
         seq_path = self.samples[idx]
-        seq_path = os.path.dirname(seq_path) + "/" # cd
         images = self._load_images(seq_path)
         masks = self._load_masks(seq_path)
         metadata = self._load_metadata(seq_path)

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -13,7 +13,8 @@ sys.path.append(str(root_path))
 
 from datasets.wayve101 import Wayve101Dataset
 from models.rig3r import Rig3R
-from utils.metrics import chamfer_distance, rig_discovery_accuracy
+from utils.metrics import align_scale, chamfer_distance, rig_discovery_accuracy
+from utils.rig_discovery import recover_pose_closed_form, reconstruct_pointcloud
 
 # -----------------------------
 # 1. Configuration
@@ -73,26 +74,54 @@ all_chamfer = []
 all_rig_acc = []
 
 for batch in tqdm(dataloader, desc="Evaluating Wayve101"):
-    images = batch['images'].to(device)            # (N,3,H,W)
+    images = batch['images'].to(device)            # (B,N,3,H,W)
     metadata = {k: v.to(device) for k, v in batch['metadata'].items() if v is not None}
-    gt_pc = batch['pointcloud'].to(device)        # (M,3)
+    gt_pc = batch['pointcloud'].to(device)         # (B,M,3)
+
+    # cam2rig is the ground truth we score against, so the model must not see it.
+    model_metadata = {k: v for k, v in metadata.items() if k != 'cam2rig'}
 
     with torch.no_grad():
-        outputs = model(images, metadata)
-        pred_pc = outputs.get('pointcloud_pred', torch.empty(0,3, device=device))
+        outputs = model(images, model_metadata)
 
-    cd = chamfer_distance(pred_pc, gt_pc)
-    rig_acc = rig_discovery_accuracy(pred_pc, gt_pc)
+    # The decoder emits pointmaps and raymaps, never a finished point cloud - the
+    # cloud is assembled here from the poses recovered out of the rig raymap.
+    rig_raymaps = outputs['rig_raymap']            # (B,N,P,6)
+    pointmaps = outputs['pointmap']                # (B,N,P,3)
+    B, N, P, _ = rig_raymaps.shape
+    H_patch = W_patch = int(P ** 0.5)
 
-    all_chamfer.append(cd.item())
-    all_rig_acc.append(rig_acc.item())
+    for b in range(B):
+        poses = [recover_pose_closed_form(rig_raymaps[b, n].reshape(H_patch, W_patch, 6))
+                 for n in range(N)]
+        pred_pc = reconstruct_pointcloud([pointmaps[b, n] for n in range(N)], poses)
+
+        # Eq. 3 normalizes only the ground truth, so predictions come out at
+        # z-bar scale. Both metrics below are in metres, so rescale first.
+        scale = align_scale(pred_pc, gt_pc[b])
+
+        cd = chamfer_distance(pred_pc * scale, gt_pc[b])
+        all_chamfer.append(cd.item())
+
+        # rig_discovery_accuracy matches rig keypoints - one 3-vector per view -
+        # under a 0.1 m threshold. Handing it the dense cloud instead measures
+        # nothing the metric is named for, and is cubic in the point count.
+        if 'cam2rig' in metadata:
+            pred_keypoints = torch.stack([p['t'] for p in poses]) * scale
+            gt_keypoints = metadata['cam2rig'][b][:, :3, 3]
+            all_rig_acc.append(rig_discovery_accuracy(pred_keypoints, gt_keypoints).item())
 
 # -----------------------------
 # 5. Report results
 # -----------------------------
-avg_chamfer = sum(all_chamfer)/len(all_chamfer)
-avg_rig_acc = sum(all_rig_acc)/len(all_rig_acc)
+if not all_chamfer:
+    raise RuntimeError("No sequences were scored - nothing to average.")
+
+avg_chamfer = sum(all_chamfer) / len(all_chamfer)
 
 print(f"\nEvaluation finished!")
-print(f"Average Chamfer Distance over {len(dataset)} sequences: {avg_chamfer:.6f}")
-print(f"Average Rig Discovery Accuracy: {avg_rig_acc:.4f}")
+print(f"Average Chamfer Distance over {len(all_chamfer)} sequences: {avg_chamfer:.6f}")
+if all_rig_acc:
+    print(f"Average Rig Discovery Accuracy: {sum(all_rig_acc)/len(all_rig_acc):.4f}")
+else:
+    print("Rig Discovery Accuracy: not scored (no cam2rig ground truth in batch)")

--- a/scripts/infer_rig_discovery.py
+++ b/scripts/infer_rig_discovery.py
@@ -59,23 +59,12 @@ def main():
         mlp_dim=4096
     )
     
-    # We need to handle the fact that we changed the head dimension.
-    # If we load a checkpoint with 3-channel head, it will fail.
-    # For this task, we assume we might be running with a new checkpoint or we handle strict=False
-    # and re-initialize the head.
-    # However, the user prompt implies we are implementing the *capability*, 
-    # and typically we would retrain. 
-    # For the purpose of the script running, we will load with strict=False for the head if needed,
-    # or just load what matches.
-    
-    try:
-        state_dict = torch.load(model_ckpt, map_location=device)
-        model.load_state_dict(state_dict, strict=False)
-        print(f"Loaded model from {model_ckpt} (strict=False)")
-    except Exception as e:
-        print(f"Failed to load checkpoint: {e}")
-        print("Initializing random model for testing flow.")
-        
+    # Strict, and no try/except: a checkpoint that fails to load used to fall through
+    # to a randomly initialized model that still printed metrics, which is the same
+    # trap as a broken pipeline reporting 0.000000. Let it raise instead.
+    model.load_state_dict(torch.load(model_ckpt, map_location=device))
+    print(f"Loaded model from {model_ckpt}")
+
     model.to(device)
     model.eval()
     
@@ -94,9 +83,6 @@ def main():
         # Ground truth poses for metrics (if available in metadata)
         # Assuming metadata contains 'cam2rig' or similar if we want to compute MAA
         # If not, we skip MAA.
-        for k, v in metadata.items():
-            print(f"Metadata {k}: {v.shape}")
-        
         # Filter out cam2rig from metadata passed to model for Rig Discovery
         # We want the model to predict rig rays without using provided extrinsics
         model_metadata = {k: v for k, v in metadata.items() if k != 'cam2rig'}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -167,11 +167,40 @@ def test_existing_metrics_are_still_here():
     print("Pre-existing metrics still present and working test passed!")
 
 
+def test_empty_input_is_nan_not_zero():
+    """A zero is a legitimate Chamfer score and a legitimate accuracy, so returning
+    zero for "there was nothing to score" let a broken pipeline print a perfect run."""
+    a = torch.randn(8, 3)
+    empty = torch.empty(0, 3)
+
+    assert torch.isnan(chamfer_distance(empty, a))
+    assert torch.isnan(chamfer_distance(a, empty))
+    assert torch.isnan(rig_discovery_accuracy(empty, a))
+    assert torch.isnan(rig_discovery_accuracy(a, empty))
+    print("Empty inputs report nan rather than a perfect score test passed!")
+
+
+def test_chunked_chamfer_matches_the_dense_answer():
+    """Chunking exists to keep a 163840 x 144005 distance matrix off the heap; it
+    must not change the number. Chunk sizes that do and do not divide N1 evenly."""
+    pc1 = torch.randn(97, 3)
+    pc2 = torch.randn(53, 3)
+
+    reference = chamfer_distance(pc1, pc2, chunk_size=10_000)  # single block
+    for chunk_size in (1, 7, 32, 96, 97, 200):
+        torch.testing.assert_close(
+            chamfer_distance(pc1, pc2, chunk_size=chunk_size), reference, atol=1e-6, rtol=0
+        )
+    print("Chunked Chamfer equals the dense Chamfer test passed!")
+
+
 if __name__ == "__main__":
     test_align_scale_recovers_a_known_factor()
     test_align_scale_survives_outliers()
     test_align_scale_handles_empty_clouds()
     test_existing_metrics_are_still_here()
+    test_empty_input_is_nan_not_zero()
+    test_chunked_chamfer_matches_the_dense_answer()
     test_identical_rays_score_zero()
     test_known_angles_are_recovered()
     test_camera_center_is_ignored()

--- a/tests/test_wayve101.py
+++ b/tests/test_wayve101.py
@@ -1,6 +1,20 @@
-from torchvision import transforms
+"""Tests for the Wayve101 dataset loader.
 
+This file used to be a print script with no assertions: under pytest it collected
+zero tests, ran at import time, and happily printed `torch.Size([1, 3])` for a
+144005-point cloud while reporting no failure. The COLMAP parser bugs it should
+have caught survived because of that.
+
+The parser tests below build their own points3D.bin, so they run in CI without
+the ~100 GB dataset. The dataset tests skip when the data is not present.
+"""
+
+import struct
 from pathlib import Path
+
+import pytest
+import torch
+
 import sys
 
 root_path = Path(__file__).parent.parent
@@ -9,31 +23,118 @@ sys.path.append(str(root_path))
 from datasets.wayve101 import Wayve101Dataset
 
 
-# --- Define transforms (optional) ---
-img_size = (128, 128)
-transform = transforms.Compose([
-    transforms.Resize(img_size),
-    transforms.ToTensor()
-])
-
-data_dir = Path.cwd().joinpath("data/wayve_scenes_101/scene_001")
-
-# --- Instantiate dataset ---
-dataset = Wayve101Dataset(
-    root_dir=data_dir,
-    n_frames=2,
-    image_size=img_size,
-    transforms=transform,
-    use_masks=True
+DATA_DIR = root_path / "data" / "wayve_scenes_101"
+needs_data = pytest.mark.skipif(
+    not (DATA_DIR / "scene_001").is_dir(),
+    reason="WayveScenes101 not downloaded (make download-wayve101)",
 )
 
-# --- Grab one sample ---
-sample = dataset[0]
 
-print("Images shape:", sample['images'].shape)       # Expect (num_cameras * n_frames, 3, H, W)
-if sample['masks'] is not None:
-    print("Masks shape:", sample['masks'].shape)     # Expect (num_cameras * n_frames, 1, H, W)
-print("Metadata keys:", sample['metadata'].keys())  # Expect dict with 'cam2rig'
-print("Cam2rig shape:", sample['metadata']['cam2rig'].shape)  # (num_cameras * n_frames, 3, 3)
-print("Pointcloud shape:", sample['pointcloud'].shape)       # (N_points, 3)
-print("Sequence path:", sample['seq_path'])
+def write_points3D_bin(path, points, track_len=3):
+    """Write a COLMAP points3D.bin containing `points`, each with `track_len` tracks.
+
+    Format: uint64 num_points, then per point
+        uint64 point_id | 3x double xyz | 3x uint8 rgb | double error
+        | uint64 track_length | track_length x (uint32 image_id, uint32 point2D_idx)
+    """
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(points)))
+        for i, (x, y, z) in enumerate(points):
+            f.write(struct.pack("<Q", 1000 + i))
+            f.write(struct.pack("<ddd", x, y, z))
+            f.write(struct.pack("<BBB", 10, 20, 30))
+            f.write(struct.pack("<d", 0.5))
+            f.write(struct.pack("<Q", track_len))
+            for t in range(track_len):
+                f.write(struct.pack("<II", t, t + 1))
+
+
+def load_pointcloud_from(tmp_path, points, track_len=3):
+    """Build a one-scene root, then read the cloud back through the dataset."""
+    scene = tmp_path / "scene" / "colmap_sparse" / "rig"
+    scene.mkdir(parents=True, exist_ok=True)
+    write_points3D_bin(scene / "points3D.bin", points, track_len=track_len)
+
+    dataset = Wayve101Dataset(root_dir=str(tmp_path))
+    return dataset._load_pointcloud(dataset.samples[0])
+
+
+def test_pointcloud_reads_every_record(tmp_path):
+    """The count is the first 8 bytes. Consuming a phantom header first made the
+    first point's id decode as the count and every field after it 8 bytes off."""
+    points = [(float(i), float(i) + 0.5, float(i) - 0.5) for i in range(50)]
+    pc = load_pointcloud_from(tmp_path, points)
+
+    assert pc.shape == (50, 3), f"expected all 50 points, parser returned {tuple(pc.shape)}"
+    torch.testing.assert_close(pc, torch.tensor(points, dtype=torch.float32))
+    print("points3D.bin returns every record test passed!")
+
+
+def test_pointcloud_skips_tracks_by_eight_bytes(tmp_path):
+    """A track element is (uint32, uint32) = 8 bytes. Skipping 16 walks past the
+    record boundary, so the next track_len decodes as garbage and the loop bails
+    out after a single point."""
+    points = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
+    for track_len in (1, 7, 64):
+        pc = load_pointcloud_from(tmp_path / f"t{track_len}", points, track_len=track_len)
+        assert pc.shape == (3, 3), f"track_len={track_len} gave {tuple(pc.shape)}"
+        torch.testing.assert_close(pc, torch.tensor(points, dtype=torch.float32))
+    print("track records are skipped 8 bytes at a time test passed!")
+
+
+def test_pointcloud_is_finite(tmp_path):
+    """A misaligned read decodes xyz from the wrong offsets and yields inf, which
+    then makes align_scale infinite and the Hungarian cost matrix infeasible."""
+    points = [(float(i), 0.0, -float(i)) for i in range(20)]
+    pc = load_pointcloud_from(tmp_path, points)
+    assert torch.isfinite(pc).all(), "parsed pointcloud contains inf/nan"
+    print("parsed pointcloud is finite test passed!")
+
+
+def test_missing_pointcloud_file_is_empty(tmp_path):
+    (tmp_path / "scene").mkdir()
+    dataset = Wayve101Dataset(root_dir=str(tmp_path))
+    assert dataset._load_pointcloud(dataset.samples[0]).shape == (0, 3)
+    print("missing points3D.bin yields an empty cloud test passed!")
+
+
+def test_truncated_file_is_empty(tmp_path):
+    scene = tmp_path / "scene" / "colmap_sparse" / "rig"
+    scene.mkdir(parents=True)
+    (scene / "points3D.bin").write_bytes(b"\x01\x02")
+
+    dataset = Wayve101Dataset(root_dir=str(tmp_path))
+    assert dataset._load_pointcloud(dataset.samples[0]).shape == (0, 3)
+    print("truncated points3D.bin yields an empty cloud test passed!")
+
+
+@needs_data
+def test_root_dir_lists_scenes_not_scene_internals():
+    """root_dir is the directory *containing* scenes. It used to be pointed at a
+    single scene, so the three "sequences" were its images/, colmap_sparse/ and
+    masks/ subdirectories, all walked back to the same scene by a dirname hack."""
+    dataset = Wayve101Dataset(root_dir=str(DATA_DIR), n_frames=2, image_size=(128, 128))
+
+    assert len(dataset) > 0
+    names = [Path(s).name for s in dataset.samples]
+    assert all(n.startswith("scene_") for n in names), names
+    assert len(set(names)) == len(names), f"duplicate sequences: {names}"
+    print(f"root_dir lists {len(names)} distinct scenes test passed!")
+
+
+@needs_data
+def test_real_sample_has_a_dense_finite_pointcloud():
+    dataset = Wayve101Dataset(root_dir=str(DATA_DIR), n_frames=2, image_size=(128, 128))
+    sample = dataset[0]
+
+    pc = sample["pointcloud"]
+    assert pc.shape[0] > 1000, f"only {pc.shape[0]} points - parser is truncating"
+    assert torch.isfinite(pc).all()
+
+    assert sample["images"].shape == (10, 3, 128, 128)
+    assert sample["metadata"]["cam2rig"].shape == (10, 4, 4)
+    print(f"real sample carries {pc.shape[0]} finite points test passed!")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -2,26 +2,39 @@
 import torch
 from scipy.optimize import linear_sum_assignment
 
-def chamfer_distance(pc1, pc2):
+def chamfer_distance(pc1, pc2, chunk_size=1024):
     """
     Compute Chamfer Distance between two point clouds.
 
     Args:
         pc1: (N1, 3) tensor
         pc2: (N2, 3) tensor
+        chunk_size: rows of pc1 held in the distance matrix at once
     Returns:
-        scalar tensor
+        scalar tensor, or nan if either cloud is empty
     """
+    # nan, not 0.0: a zero here is indistinguishable from a perfect score, so an
+    # empty prediction used to read as a flawless reconstruction.
     if pc1.numel() == 0 or pc2.numel() == 0:
-        return torch.tensor(0.0, device=pc1.device)
+        return torch.tensor(float('nan'), device=pc1.device)
 
-    pc1 = pc1.unsqueeze(0)  # (1, N1, 3)
-    pc2 = pc2.unsqueeze(0)  # (1, N2, 3)
+    pc1 = pc1.reshape(-1, 3)
+    pc2 = pc2.reshape(-1, 3)
 
-    diff = torch.cdist(pc1, pc2)  # (1, N1, N2)
-    dist1 = diff.min(dim=2)[0].mean()
-    dist2 = diff.min(dim=1)[0].mean()
-    return dist1 + dist2
+    # A full cdist is N1 x N2 floats - 163840 predicted points against 144005
+    # ground-truth ones is 94 GB. Chunking over pc1 keeps peak memory at
+    # chunk_size x N2 while giving the exact same answer as the dense version:
+    # min over pc2 is per-chunk, min over pc1 is a running min across chunks.
+    min_over_pc2 = []
+    min_over_pc1 = torch.full((pc2.shape[0],), float('inf'),
+                              device=pc2.device, dtype=pc2.dtype)
+
+    for start in range(0, pc1.shape[0], chunk_size):
+        block = torch.cdist(pc1[start:start + chunk_size], pc2)  # (chunk, N2)
+        min_over_pc2.append(block.min(dim=1)[0])
+        min_over_pc1 = torch.minimum(min_over_pc1, block.min(dim=0)[0])
+
+    return torch.cat(min_over_pc2).mean() + min_over_pc1.mean()
 
 
 def rig_discovery_accuracy(pred_pc, gt_pc):
@@ -33,10 +46,12 @@ def rig_discovery_accuracy(pred_pc, gt_pc):
         gt_pc: (N, 3) ground truth rig keypoints
 
     Returns:
-        fraction of correctly matched points
+        fraction of correctly matched points, or nan if either input is empty
     """
+    # nan rather than 0.0 - see chamfer_distance. Zero is a legitimate score here,
+    # so it must not double as "there was nothing to score".
     if pred_pc.numel() == 0 or gt_pc.numel() == 0:
-        return torch.tensor(0.0, device=pred_pc.device)
+        return torch.tensor(float('nan'), device=pred_pc.device)
 
     # Compute distance matrix
     dist_matrix = torch.cdist(pred_pc.unsqueeze(0), gt_pc.unsqueeze(0))[0].cpu().numpy()  # (N_pred, N_gt)


### PR DESCRIPTION
Neither evaluation entry point worked. `scripts/evaluate.py` exited 0 with every metric at
`0.000000`; `scripts/infer_rig_discovery.py` died with `ValueError: cost matrix is
infeasible`. The `evaluate.py` case was the dangerous one — a run reporting
`Average Chamfer Distance: 0.000000` reads as a perfect score, not as a broken pipeline.

| | before | after |
|---|---|---|
| `evaluate.py` Chamfer | `0.000000` (guard clause) | `22.395426` |
| `infer_rig_discovery.py` | `ValueError: cost matrix is infeasible` | Chamfer `25.47`, mAA `119.23°` |
| `points3D.bin` parse | 1 point of 144005, containing `-inf` | 144005 points, all finite |

## The root cause: two bugs in the COLMAP parser, not one

The issue identified a duplicated header read. There is a second, independent bug in the
same function, and **fixing either one alone leaves the parser broken**.

```python
# before — datasets/wayve101.py
with open(file_path, 'rb') as f:
    header = f.read(8)                               # <- this IS num_points
    if len(header) < 8:
        return torch.empty(0, 3)
    num_points = struct.unpack('<Q', f.read(8))[0]   # <- first point's point_id
    ...
        bytes_to_skip = track_len * 16               # <- track element is 8 bytes
```

```python
# after
count = f.read(8)
if len(count) < 8:
    return torch.empty(0, 3)
num_points = struct.unpack('<Q', count)[0]
...
    f.seek(track_len * 8, os.SEEK_CUR)
```

**Bug 1 — the phantom header.** `points3D.bin` is a `uint64` count followed immediately by
the records; there is no separate header. The first `read(8)` already consumed the count,
so the second read took the first record's `point_id` and treated it as the count:

```
bytes[0:8]  (true num_points) = 144005
bytes[8:16] (what the code used) = 658643
```

**Bug 2 — the track stride.** A track element is `(uint32 image_id, uint32 point2D_idx)` =
**8 bytes**, not 16. Skipping 16 walks past the record boundary, so the next `track_len`
decodes as garbage and the loop breaks out at EOF.

Measured on `scene_001/colmap_sparse/rig/points3D.bin`, with the header bug already fixed:

```
track*16 (old stride) -> insane track_len 6408091205816 after 1 points
   parsed (1, 3) of declared 144005
track*8  (COLMAP spec) -> parsed (144005, 3) of declared 144005 | finite True
   median norm 19.388  max 207.166
```

So the issue's "highest priority" fix still yields a 1-point cloud on its own. Both bugs
had to go together.

The 1 MB chunked-skip loop went with them. It only ever existed to survive the absurd
`track_len` values bug 2 produced; with the correct stride, `f.seek` is one line.

**Downstream:** the `-inf` in the parsed cloud made `align_scale` return `inf`, which made
`pred_pc * scale` all `inf`/`nan`, which is what `linear_sum_assignment` rejected as
infeasible. The crash was in the metric; the bug was in the loader. With both parser bugs
fixed, all 144005 points are finite — no filtering needed.

## `root_dir` semantics

`__init__` treated every subdirectory of `root_dir` as a sequence, but `__getitem__`
immediately walked back up one level:

```python
seq_path = os.path.dirname(seq_path) + "/" # cd
```

With `data: "data/wayve_scenes_101/scene_001"`, the three "sequences" were that scene's own
`images/`, `colmap_sparse/` and `masks/` directories, all `dirname`'d back to `scene_001/`.
"3 sequences" was one scene evaluated three times.

Settled on the `__init__` convention: `root_dir` contains scenes. The `dirname` line is
gone and both configs point at `data/wayve_scenes_101`. Still 3 sequences — the `isdir`
filter already excludes the downloaded `.zip` archives — but now 3 *distinct* scenes.

`samples` is now `sorted()`. `os.listdir` order is arbitrary, and now that entries are real
scenes, `scripts/visualize.py --seq-idx` needs to mean the same scene across machines.

## `evaluate.py` — kept, not deleted

The issue suggested deleting `scripts/evaluate.py` and pointing `make evaluate` at
`infer_rig_discovery.py`. This PR does not do that. `make evaluate` is the canonical entry
point, and `infer_rig_discovery.py` is a research script that (at the time) carried
per-batch debug prints and a `strict=False` random-model fallback. Repointing the Makefile
at it would promote the worse file. The shared geometry already lives in
`utils/rig_discovery.py`, so `evaluate.py` calls those helpers rather than re-deriving
them.

**It read an output key the model never emits.** `outputs.get('pointcloud_pred', ...)`
always returned its `torch.empty(0, 3)` default — the decoder emits `pointmap`,
`pointmap_conf`, `pose_raymap`, `rig_raymap`, `camera_center_pose`, `camera_center_rig`,
`features`. Both metrics then hit their empty-input guards and returned a hardcoded zero.
Because `.get()` swallowed the missing key this never raised — and it also kept the parser
bug invisible here, since an empty prediction never touches the garbage ground truth.

**It scored rig discovery against a dense point cloud.** `rig_discovery_accuracy` is
documented for `(N, 3)` rig keypoints and its 0.1 m threshold is calibrated for them.
`evaluate.py` handed it point clouds — 163840 predicted against 144005 ground-truth points,
cubic in the point count, and not the quantity the metric names.

Now it recovers one pose per view from the rig raymap, assembles the cloud through
`reconstruct_pointcloud`, applies `align_scale` before any metric in metres, and passes
`torch.stack([p['t'] for p in poses]) * scale` against `cam2rig[:, :3, 3]`.

It also stops feeding `cam2rig` to the model. `infer_rig_discovery.py` already stripped it;
`evaluate.py` was passing the ground truth being scored straight into the forward pass —
the same leak class as #38.

## Chamfer would have OOM'd the moment a prediction reached it

`chamfer_distance` built a dense `torch.cdist`. Flattening `pointmap` gives
`10 * 16384 = 163840` predicted points against 144005 ground-truth points:

```
163840 * 144005 * 4 bytes = 94.4 GB
```

for the distance matrix alone. Fixing the output key without this would have traded a fake
zero for an OOM. The min-reduction is now chunked over `pc1` rows: min over `pc2` is
per-chunk, min over `pc1` is a running min across chunks. Exact — no subsampling, same
answer as the dense version — at `chunk_size x N2` peak, 590 MB at the default 1024.

## Empty input returns `nan`, not `0.0`

Both guards returned `torch.tensor(0.0)`. Zero is a legitimate Chamfer distance and a
legitimate accuracy, so it could not also mean "there was nothing to score" — that is
exactly how the broken pipeline printed a perfect run. They now return `nan`.

Checked every caller: only these two scripts. `tests/test_metrics.py:162` asserts on
*identical* clouds, not empty ones, so it is unaffected. Nothing in training consumes these.

This is what makes the new `Rig Discovery Accuracy: 0.0000` trustworthy — an empty input
would now print `nan`, so a printed zero means keypoints really were matched and really
missed the 0.1 m threshold.

## `infer_rig_discovery.py` hardening

```python
# before
try:
    state_dict = torch.load(model_ckpt, map_location=device)
    model.load_state_dict(state_dict, strict=False)
except Exception as e:
    print(f"Failed to load checkpoint: {e}")
    print("Initializing random model for testing flow.")
```

On any load failure this fell through to a **randomly initialized model that still printed
metrics** — the same trap as `0.000000`, one layer up. Now a strict load with no `except`.
The issue confirms `rig3r_epoch5.pt` loads strict-clean with zero missing or unexpected
keys, and the run below confirms it.

Also dropped the per-batch `print(f"Metadata {k}: {v.shape}")`.

## Files

- `datasets/wayve101.py` — both parser bugs; `dirname` hack removed; `sorted()` samples;
  `root_dir` docstring.
- `scripts/evaluate.py` — real outputs, `align_scale`, keypoints not clouds, `cam2rig`
  withheld from the forward, empty-result guard on the report.
- `scripts/infer_rig_discovery.py` — strict checkpoint load, debug prints removed.
- `utils/metrics.py` — chunked Chamfer, `nan` on empty.
- `configs/evaluate.yaml`, `configs/evaluate_mini.yaml` — `data:` → `data/wayve_scenes_101`.
- `tests/test_wayve101.py` — rewritten (below).
- `tests/test_metrics.py` — two new tests.

8 files, +253 −92.

`scripts/visualize.py` needed no change: it reads `configs/evaluate.yaml`, so it picks up
the new convention, and its `--seq-idx 0..2` now selects real scenes.

## Tests

`tests/test_wayve101.py` was a print script with no assertions. Under pytest it collected
zero test functions and reported no failure, while printing `torch.Size([1, 3])` for a
144005-point cloud. That is why both parser bugs survived.

It is now real tests, and the parser tests **build their own `points3D.bin`** via
`write_points3D_bin` — so they catch both bugs in CI without the ~100 GB dataset. Two
real-data tests skip when the download is absent.

- **`test_pointcloud_reads_every_record`** — 50 points in, 50 points out, values compared
  exactly. Fails on bug 1.
- **`test_pointcloud_skips_tracks_by_eight_bytes`** — same 3 points at `track_len` 1, 7 and
  64. Fails on bug 2, which the single-fixture case can mask.
- **`test_pointcloud_is_finite`** — the `-inf` that made the cost matrix infeasible.
- **`test_missing_pointcloud_file_is_empty`**, **`test_truncated_file_is_empty`** — the
  short-file guard, now hung off the count read.
- **`test_root_dir_lists_scenes_not_scene_internals`** *(needs data)* — asserts every
  sample is a `scene_*` and that there are no duplicates. Fails on the `dirname` hack.
- **`test_real_sample_has_a_dense_finite_pointcloud`** *(needs data)* — asserts
  `shape[0] > 1000` and `isfinite().all()`. This one line would have caught bug 1 the day
  it landed.

`tests/test_metrics.py` gained **`test_empty_input_is_nan_not_zero`** and
**`test_chunked_chamfer_matches_the_dense_answer`** — the latter across chunk sizes that
do and do not divide `N1` evenly (1, 7, 32, 96, 97, 200), since chunking exists purely for
memory and must not move the number.

### Results

```
tests/test_wayve101.py tests/test_metrics.py    21 passed in 1.72s
tests/                                         125 passed, 42 warnings in 22.86s
```

Both entry points, end to end on `configs/evaluate_mini.yaml`:

```
$ python scripts/evaluate.py --config configs/evaluate_mini.yaml
Loaded 3 sequences from Wayve101
Loaded model from checkpoints/rig3r_epoch5.pt
Evaluating Wayve101: 100%|██████████| 3/3 [00:08<00:00,  2.67s/it]

Evaluation finished!
Average Chamfer Distance over 3 sequences: 22.395426
Average Rig Discovery Accuracy: 0.0000
```

```
$ python scripts/infer_rig_discovery.py --config configs/evaluate_mini.yaml
Loaded 3 sequences.
Loaded model from checkpoints/rig3r_epoch5.pt
Rig Discovery: 100%|██████████| 3/3 [00:07<00:00,  2.36s/it]

=== Rig Discovery Results ===
Avg Chamfer Distance: 25.471368
Avg Rig ID Accuracy:  0.0000
Avg Rig mAA (deg):    119.2331
```

## How to read those numbers

- **mAA 119° is the model, not the pipeline.** Uniformly random rotations average ~120°.
  This is an epoch-5 checkpoint; that is roughly what it should look like. The point of
  this PR is that the pipeline now reports it instead of hiding it behind a zero.
- **Rig accuracy 0.0000 is a genuine score.** Empty input returns `nan` now, so a printed
  zero means 10 predicted keypoints were matched against 10 ground-truth ones and none
  landed within 0.1 m. Consistent with a 22 m Chamfer.
- **These are the first real Wayve101 numbers in the repo.** There is no prior baseline to
  regress against — every number before this PR was a guard clause.

## Notes for review

- **Evaluation is not reproducible run to run.** The 22.4 vs 25.5 gap between the two runs
  above is not a discrepancy between the scripts — both take the identical geometry path.
  It is `_sample_frames` using `random.sample`, so the two runs scored different frames.
  Left alone here: it is not one of the defects in #49 and it deserves its own change
  (a seed, or deterministic frame selection for eval). Worth filing.
- **`n_frames = 2` and `image_size = (128, 128)` are still hardcoded** in both scripts while
  only `checkpoint` and `data` come from the config. Noted as "Minor" in #49; skipped
  because no second resolution exists yet.
- **`evaluate.py` and `infer_rig_discovery.py` still overlap.** They now share the geometry
  through `utils/rig_discovery` rather than duplicating it, but the loading and reporting
  scaffolding is parallel. `infer_rig_discovery.py` keeps what is genuinely its own —
  pose clustering and rig mAA. If the overlap is still too much, the merge is a separate
  change; doing it here would have buried the bug fixes.
- **Chamfer's `chunk_size=1024` is a default, not a tuned value.** It bounds peak memory at
  `chunk_size x N2 x 4` bytes. Raise it on a large GPU if the 160 chunks per scene ever
  show up in a profile.
