### PR TITLE
Source evaluation geometry from config, and stop `patch_size` defaulting to a value that cannot load

### DIFF
--- a/configs/evaluate.yaml
+++ b/configs/evaluate.yaml
@@ -1,2 +1,9 @@
 checkpoint: "checkpoints/rig3r_epoch50.pt"
 data: "data/wayve_scenes_101"
+
+# Must match the checkpoint: image_size sets the encoder pos_embed length, so a
+# wrong value fails the strict load rather than scoring the wrong model. n_frames
+# is the exception - views are a runtime dimension, so it is free to differ from
+# training if you want to evaluate at more or fewer frames.
+n_frames: 2
+image_size: [128, 128]

--- a/configs/evaluate_mini.yaml
+++ b/configs/evaluate_mini.yaml
@@ -1,2 +1,6 @@
 checkpoint: "checkpoints/rig3r_epoch5.pt"
 data: "data/wayve_scenes_101"
+
+# See configs/evaluate.yaml. image_size must match the checkpoint; n_frames is free.
+n_frames: 2
+image_size: [128, 128]

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -12,8 +12,9 @@ root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
 from datasets.wayve101 import Wayve101Dataset
+from models.encoder_vit import DUST3R_ENCODER
 from models.rig3r import Rig3R
-from utils.metrics import align_scale, chamfer_distance, rig_discovery_accuracy
+from utils.metrics import align_scale, chamfer_distance, rig_discovery_accuracy, rig_maa
 from utils.rig_discovery import recover_pose_closed_form, reconstruct_pointcloud
 
 # -----------------------------
@@ -34,9 +35,15 @@ args = parse_args()
 eval_cfg = load_config(args.config)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 data_root = Path.cwd().joinpath(eval_cfg["data"])
-n_frames = 2
-image_size = (128, 128)
+n_frames = eval_cfg.get("n_frames", 2)
+image_size = tuple(eval_cfg.get("image_size", [128, 128]))
 batch_size = 1  # evaluation usually works with 1
+
+# patch_size is not read from config: the DUSt3R ViT-L/16 encoder pins it, so a
+# config key would have exactly one legal value. A wrong image_size or patch_size
+# cannot go unnoticed either way - both change parameter shapes, so the strict
+# load below raises rather than scoring the wrong model.
+patch_size = DUST3R_ENCODER["patch_size"]
 
 # -----------------------------
 # 2. Load dataset
@@ -56,7 +63,7 @@ print(f"Loaded {len(dataset)} sequences from Wayve101")
 model_ckpt = Path.cwd().joinpath(eval_cfg["checkpoint"])
 model = Rig3R(
     img_size=image_size[0],
-    patch_size=16,
+    patch_size=patch_size,
     embed_dim=1024,
     num_decoder_layers=2,
     num_heads=8,
@@ -72,6 +79,7 @@ print(f"Loaded model from {model_ckpt}")
 # -----------------------------
 all_chamfer = []
 all_rig_acc = []
+all_rig_maa = []
 
 for batch in tqdm(dataloader, desc="Evaluating Wayve101"):
     images = batch['images'].to(device)            # (B,N,3,H,W)
@@ -107,9 +115,16 @@ for batch in tqdm(dataloader, desc="Evaluating Wayve101"):
         # under a 0.1 m threshold. Handing it the dense cloud instead measures
         # nothing the metric is named for, and is cubic in the point count.
         if 'cam2rig' in metadata:
+            gt_cam2rig = metadata['cam2rig'][b]
+
             pred_keypoints = torch.stack([p['t'] for p in poses]) * scale
-            gt_keypoints = metadata['cam2rig'][b][:, :3, 3]
+            gt_keypoints = gt_cam2rig[:, :3, 3]
             all_rig_acc.append(rig_discovery_accuracy(pred_keypoints, gt_keypoints).item())
+
+            # Rotation-only, so no align_scale and no metres: unlike Chamfer, this
+            # stays comparable across changes to the scale convention.
+            gt_poses = [{'R': gt_cam2rig[n, :3, :3]} for n in range(N)]
+            all_rig_maa.append(rig_maa(poses, gt_poses).item())
 
 # -----------------------------
 # 5. Report results
@@ -123,5 +138,6 @@ print(f"\nEvaluation finished!")
 print(f"Average Chamfer Distance over {len(all_chamfer)} sequences: {avg_chamfer:.6f}")
 if all_rig_acc:
     print(f"Average Rig Discovery Accuracy: {sum(all_rig_acc)/len(all_rig_acc):.4f}")
+    print(f"Average Rig mAA (deg): {sum(all_rig_maa)/len(all_rig_maa):.4f}")
 else:
-    print("Rig Discovery Accuracy: not scored (no cam2rig ground truth in batch)")
+    print("Rig metrics: not scored (no cam2rig ground truth in batch)")

--- a/scripts/infer_rig_discovery.py
+++ b/scripts/infer_rig_discovery.py
@@ -10,6 +10,7 @@ import sys
 root_path = Path(__file__).parent.parent
 sys.path.append(str(root_path))
 
+from models.encoder_vit import DUST3R_ENCODER
 from models.rig3r import Rig3R
 from utils.metrics import align_scale, chamfer_distance, rig_discovery_accuracy, rig_maa
 from utils.rig_discovery import recover_pose_closed_form, cluster_rig_poses, reconstruct_pointcloud
@@ -34,8 +35,11 @@ def main():
     # 1. Load Dataset
     # We use Wayve101 as in evaluate.py, or whatever is specified in config
     data_root = Path.cwd().joinpath(cfg["data"])
-    n_frames = 2 # Fixed for this task/test
-    image_size = (128, 128)
+    n_frames = cfg.get("n_frames", 2)
+    image_size = tuple(cfg.get("image_size", [128, 128]))
+    # See scripts/evaluate.py: patch_size is pinned by the DUSt3R encoder, and a
+    # wrong image_size fails the strict load rather than passing silently.
+    patch_size = DUST3R_ENCODER["patch_size"]
     
     # Note: Wayve101Dataset might need to be imported or mocked if not available in context, 
     # but based on evaluate.py it exists.
@@ -52,7 +56,7 @@ def main():
     model_ckpt = Path.cwd().joinpath(cfg["checkpoint"])
     model = Rig3R(
         img_size=image_size[0],
-        patch_size=16,
+        patch_size=patch_size,
         embed_dim=1024,
         num_decoder_layers=2,
         num_heads=8,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,6 +22,7 @@ from datasets.transform import get_train_transforms, get_val_transforms
 
 # --- Import model ---
 from models.rig3r import Rig3R
+from models.encoder_vit import DUST3R_ENCODER
 from models.losses import MultiTaskLoss
 from utils.amp import needs_grad_scaler, select_amp_dtype
 from utils.metrics import raymap_metrics
@@ -61,7 +62,18 @@ dataset_type = train_cfg.get("dataset_type", "co3d")
 # 2. Prepare datasets
 # -----------------------------
 img_size = tuple(train_cfg.get("image_size", [128, 128]))
-patch_size = train_cfg.get("patch_size", 8)
+
+# patch_size is not a free parameter while the DUSt3R encoder is in use: it pins
+# ViT-L/16 and models/encoder_vit.py loads strict. Reading it from config only
+# created a way to get it wrong - configs/train_mini.yaml omitted the key and took
+# the old default of 8, which cannot load the encoder at all. It also sets the
+# raymap target resolution.
+patch_size = DUST3R_ENCODER["patch_size"]
+if train_cfg.get("patch_size", patch_size) != patch_size:
+    raise ValueError(
+        f"config sets patch_size={train_cfg['patch_size']}, but the DUSt3R encoder "
+        f"is fixed at {patch_size}. Drop the key rather than have it silently ignored."
+    )
 
 if dataset_type == "co3d":
     co3d_path = Path.cwd().joinpath("data/co3d")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,71 @@
+"""The shipped configs must agree with what the model can actually build.
+
+configs/train_mini.yaml omitted `patch_size` and picked up scripts/train.py's default
+of 8, which cannot load the ViT-L/16 DUSt3R encoder at all - `make train-debug` died at
+model construction. Nothing caught it because no test read the configs.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+root_path = Path(__file__).parent.parent
+sys.path.append(str(root_path))
+
+from models.encoder_vit import DUST3R_ENCODER
+
+CONFIG_DIR = root_path / "configs"
+CONFIGS = sorted(CONFIG_DIR.glob("*.yaml"))
+EVAL_CONFIGS = sorted(CONFIG_DIR.glob("evaluate*.yaml"))
+
+
+def load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def test_configs_exist():
+    assert CONFIGS, f"no configs found in {CONFIG_DIR}"
+    assert EVAL_CONFIGS, f"no evaluate*.yaml found in {CONFIG_DIR}"
+
+
+@pytest.mark.parametrize("path", CONFIGS, ids=lambda p: p.name)
+def test_patch_size_never_contradicts_the_encoder(path):
+    """patch_size is pinned by the DUSt3R encoder. A config may omit it - the scripts
+    take it from DUST3R_ENCODER - but must never set it to something else."""
+    patch_size = load(path).get("patch_size")
+    if patch_size is not None:
+        assert patch_size == DUST3R_ENCODER["patch_size"], (
+            f"{path.name} sets patch_size={patch_size}, encoder is fixed at "
+            f"{DUST3R_ENCODER['patch_size']}"
+        )
+
+
+@pytest.mark.parametrize("path", CONFIGS, ids=lambda p: p.name)
+def test_image_size_is_divisible_by_the_patch_size(path):
+    """A non-divisible image_size gives a fractional patch grid, so the raymap and
+    pointmap heads silently read off a grid that does not tile the image."""
+    image_size = load(path).get("image_size")
+    if image_size is None:
+        return
+
+    patch = DUST3R_ENCODER["patch_size"]
+    assert len(image_size) == 2, f"{path.name}: image_size must be [H, W], got {image_size}"
+    for side in image_size:
+        assert side % patch == 0, f"{path.name}: image_size {image_size} not divisible by {patch}"
+
+
+@pytest.mark.parametrize("path", EVAL_CONFIGS, ids=lambda p: p.name)
+def test_eval_configs_carry_their_geometry(path):
+    """Evaluation geometry used to be hardcoded in the scripts while only `checkpoint`
+    and `data` came from config, so evaluating a model trained at another resolution
+    meant editing source."""
+    cfg = load(path)
+    for key in ("checkpoint", "data", "n_frames", "image_size"):
+        assert key in cfg, f"{path.name} is missing '{key}'"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## The premise this branch started from was wrong

The branch is named `silent-mismatch` after the theory it was built to fix: that
`scripts/evaluate.py` hardcoding `image_size = (128, 128)` and `patch_size = 16` meant a
model trained at another resolution would be evaluated silently against the wrong
geometry. #47 argued this, and so did my draft of the follow-up issue.

It does not happen. `encoder.vit.pos_embed` is an `nn.Parameter`, so it is in the
`state_dict`, and its length is the patch count:

```
encoder.vit.pos_embed                (1, 64, 1024)      # 64 = (128/16)^2
encoder.vit.patch_embed.proj.weight  (1024, 3, 16, 16)
```

`evaluate.py` loads strict. Any `image_size` or `patch_size` drift changes a parameter
shape and raises:

```
img_size=128: loaded OK
img_size=256: RuntimeError: size mismatch for encoder.vit.pos_embed:
              copying a param with shape torch.Size([1, 64, 1024]) from checkpoint
```

| value | mismatch caught? | by what |
|---|---|---|
| `image_size` | yes | `encoder.vit.pos_embed` length |
| `patch_size` | yes | `patch_embed.proj.weight` shape |
| `embed_dim`, heads, layers, `mlp_dim` | yes | strict load |
| `n_frames` | no | runtime view count, not a parameter shape |

So there was nothing silent to fix, and this PR does not add a mismatch check — the strict
load already is one. What the investigation did turn up is a real bug in the opposite
direction, on the training side.

## The actual bug: `train.py` defaulted `patch_size` to 8

`scripts/train.py:64`:

```python
patch_size = train_cfg.get("patch_size", 8)
```

`configs/train_mini.yaml` does not set `patch_size`, so it took that default.
`models/encoder_vit.py:12` pins the DUSt3R encoder to 16, and `scripts/train.py` always
passes `encoder_ckpt=`, so the strict load in `_load_dust3r_weights` cannot succeed.
`make train-debug` died at model construction:

```
RuntimeError: Error(s) in loading state_dict for VisionTransformer:
```

The fix is deletion rather than correction. Defaulting to 16 would leave a knob whose only
legal value is 16:

```python
# after
patch_size = DUST3R_ENCODER["patch_size"]
if train_cfg.get("patch_size", patch_size) != patch_size:
    raise ValueError(
        f"config sets patch_size={train_cfg['patch_size']}, but the DUSt3R encoder "
        f"is fixed at {patch_size}. Drop the key rather than have it silently ignored."
    )
```

The guard exists so removing the config key does not create a *new* silent failure — a
config that sets `patch_size: 8` would otherwise be quietly ignored, which is the same
class of problem one layer along. Verified firing:

```
$ python scripts/train.py --config <train_mini.yaml + patch_size: 8>
ValueError: config sets patch_size=8, but the DUSt3R encoder is fixed at 16.
Drop the key rather than have it silently ignored.
```

`configs/train_waymo.yaml` already sets `patch_size: 16`, which agrees, so it passes
untouched. `configs/train_mini.yaml` now builds and loads all 292 encoder tensors.

## `n_frames` and `image_size` now come from the eval config

`n_frames` is the one hardcoded value the checkpoint does *not* pin, because views are a
runtime dimension the decoder handles variably. A mismatch is therefore not corruption —
evaluating a 2-frame-trained model at 4 frames is a legitimate experiment — but it was not
runnable without editing source. That is the real gap, and it is the opposite of what #47
described.

`image_size` is included for ergonomics only: evaluating a model trained at 256 meant
editing `evaluate.py`. The strict load still catches a wrong value, so this makes a loud
failure avoidable rather than preventing a quiet one.

```yaml
# configs/evaluate.yaml
checkpoint: "checkpoints/rig3r_epoch50.pt"
data: "data/wayve_scenes_101"

# Must match the checkpoint: image_size sets the encoder pos_embed length, so a
# wrong value fails the strict load rather than scoring the wrong model. n_frames
# is the exception - views are a runtime dimension, so it is free to differ from
# training if you want to evaluate at more or fewer frames.
n_frames: 2
image_size: [128, 128]
```

`patch_size` is deliberately **not** a config key here, for the same reason it stopped
being one in `train.py`. All three scripts now read it from `DUST3R_ENCODER`, so the value
cannot drift between training and evaluation again. `batch_size` stays hardcoded at 1: a
config key nothing varies is a knob that only creates ways to be wrong.

## `evaluate.py` now reports rig mAA

#47 item 4. `utils/metrics.py:rig_maa` was implemented and reported by
`infer_rig_discovery.py`, but `evaluate.py` neither imported nor printed it. The recovered
poses were already in scope, so it slots into the existing `cam2rig` block:

```python
gt_poses = [{'R': gt_cam2rig[n, :3, :3]} for n in range(N)]
all_rig_maa.append(rig_maa(poses, gt_poses).item())
```

Worth having in the canonical entry point specifically because it is rotation-only: no
`align_scale`, no metres, so it stays comparable across changes to the scale convention in
a way Chamfer distance does not.

## Files

- `scripts/train.py` — `patch_size` from `DUST3R_ENCODER` plus the disagreement guard.
- `scripts/evaluate.py` — `n_frames` / `image_size` from config, `patch_size` from
  `DUST3R_ENCODER`, rig mAA reported.
- `scripts/infer_rig_discovery.py` — same config wiring; drops the
  `# Fixed for this task/test` hardcoding.
- `configs/evaluate.yaml`, `configs/evaluate_mini.yaml` — `n_frames`, `image_size`.
- `tests/test_configs.py` — new, 71 lines.

5 files changed, +55 −12, plus the new test file.

## Tests

`tests/test_configs.py` is new because **nothing read the configs**. That is the whole
reason `train_mini.yaml` was able to drift into an unbuildable state and stay there. 13
parametrized cases across every `configs/*.yaml`:

- **`test_patch_size_never_contradicts_the_encoder`** — a config may omit `patch_size` (the
  scripts supply it) but must never set a different one. This is the regression guard for
  the bug above.
- **`test_image_size_is_divisible_by_the_patch_size`** — a non-divisible `image_size` gives
  a fractional patch grid, so the heads read off a grid that does not tile the image.
- **`test_eval_configs_carry_their_geometry`** — `checkpoint`, `data`, `n_frames`,
  `image_size` all present.
- **`test_configs_exist`** — so the parametrized tests cannot pass vacuously by globbing an
  empty directory.

```
tests/test_configs.py    13 passed in 1.95s
tests/                   138 passed in 24.60s     (was 125 on #50)
```

Both entry points end to end on `configs/evaluate_mini.yaml`:

```
$ python scripts/evaluate.py --config configs/evaluate_mini.yaml
Average Chamfer Distance over 3 sequences: 28.909298
Average Rig Discovery Accuracy: 0.0000
Average Rig mAA (deg): 119.9871
```

```
$ python scripts/infer_rig_discovery.py --config configs/evaluate_mini.yaml
Avg Chamfer Distance: 24.250818
Avg Rig ID Accuracy:  0.0000
Avg Rig mAA (deg):    117.0640
```


## Notes for review

- **The spread in those numbers is not from this PR.** Chamfer 28.9 vs 24.3 across the two
  runs is `_sample_frames` using `random.sample` — the non-determinism flagged in #50.
  Nothing here touches the geometry path. This should be fixed before anyone treats these
  numbers as a baseline; it needs its own change (a seed, or deterministic frame selection
  for eval).
- **mAA near 120 degrees is the checkpoint, not the metric.** Uniformly random rotations
  average about that. `rig3r_epoch5.pt` is undertrained. The two scripts now agree on the
  metric to within the frame-sampling noise, which is the useful signal here.
- **The branch name is now misleading.** `silent-mismatch` describes a bug that does not
  exist. Worth renaming before merge, or squashing with a message that does not carry the
  false premise forward into the history.
- **#47 can be closed with this.** #50 fixed its two headline defects; this closes item 4
  (rig mAA) and the config hardcoding. Its "so an evaluation silently mismatches a model
  trained at any other resolution or patch size instead of failing loudly" claim should be
  corrected in the closing comment rather than repeated — it is the opposite of what the
  strict load does.
- **Not done:** unifying `scripts/visualize.py`, which takes `--n-frames` and
  `--image-size` as CLI flags with their own defaults — a third convention alongside the
  train and eval configs. Larger change, and its flags at least make the values visible at
  the call site rather than buried in source.
